### PR TITLE
Refactor pay-slip fetch endpoints and implement admin filtering (#34, #36)

### DIFF
--- a/pay-slip-app/backend/api/openapi.yaml
+++ b/pay-slip-app/backend/api/openapi.yaml
@@ -306,14 +306,16 @@ paths:
 
     get:
       tags: [PaySlips]
-      summary: List pay slips
+      summary: List my pay slips
+      description: Returns only the pay slips belonging to the authenticated user.
       parameters:
         - name: limit
           in: query
-          description: Max number of records to return (default 20, max 100)
+          description: Max number of records to return (default 20, max 50)
           schema:
             type: integer
             default: 20
+            maximum: 50
         - name: cursor
           in: query
           description: Pagination cursor from previous response
@@ -326,6 +328,59 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PaySlipsResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /api/pay-slips/all:
+    get:
+      tags: [PaySlips]
+      summary: List all pay slips [admin only]
+      description: Returns all pay slips across all users. Supports optional filtering by userId and period.
+      parameters:
+        - name: limit
+          in: query
+          description: Max number of records to return (default 20, max 50)
+          schema:
+            type: integer
+            default: 20
+            maximum: 50
+        - name: cursor
+          in: query
+          description: Pagination cursor from previous response
+          schema:
+            type: string
+        - name: userId
+          in: query
+          description: Filter by a specific user ID
+          schema:
+            type: string
+        - name: year
+          in: query
+          description: Filter by year
+          schema:
+            type: integer
+            example: 2025
+        - name: month
+          in: query
+          description: Filter by month (1-12)
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 12
+            example: 3
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PaySlipsResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
 
   /api/pay-slips/{id}:
     get:

--- a/pay-slip-app/backend/cmd/main.go
+++ b/pay-slip-app/backend/cmd/main.go
@@ -72,7 +72,8 @@ func main() {
 	// Pay slip endpoints
 	mux.Handle("POST /api/upload", auth(http.HandlerFunc(h.UploadFile)))
 	mux.Handle("POST /api/pay-slips", auth(http.HandlerFunc(h.CreatePaySlip)))
-	mux.Handle("GET /api/pay-slips", auth(http.HandlerFunc(h.GetPaySlips)))
+	mux.Handle("GET /api/pay-slips", auth(http.HandlerFunc(h.GetMyPaySlips)))
+	mux.Handle("GET /api/pay-slips/all", auth(http.HandlerFunc(h.GetAllPaySlips)))
 	mux.Handle("GET /api/pay-slips/{id}", auth(http.HandlerFunc(h.GetPaySlipByID)))
 	mux.Handle("DELETE /api/pay-slips/{id}", auth(http.HandlerFunc(h.DeletePaySlip)))
 

--- a/pay-slip-app/backend/internal/handlers/payslip_handlers.go
+++ b/pay-slip-app/backend/internal/handlers/payslip_handlers.go
@@ -116,77 +116,77 @@ func (h *Handler) CreatePaySlip(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, http.StatusCreated, ps)
 }
 
-// GetPaySlips handles GET /api/pay-slips
-func (h *Handler) GetPaySlips(w http.ResponseWriter, r *http.Request) {
+// GetMyPaySlips handles GET /api/pay-slips - Returns only the caller's own pay slips
+func (h *Handler) GetMyPaySlips(w http.ResponseWriter, r *http.Request) {
 	currentUser := mustGetUser(r)
 	if currentUser == nil {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 
-	isAdmin := currentUser.Role == string(constants.RoleAdmin)
-
-	// 1. Parse Pagination Params
-	limitStr := r.URL.Query().Get("limit")
-	cursorStr := r.URL.Query().Get("cursor")
-
-	var limit int
-	if limitStr != "" {
-		limit, _ = strconv.Atoi(limitStr)
-	}
-	if limit <= 0 {
-		limit = 20 // Default limit if not specified or invalid
+	limit, afterID, afterCreatedAt, err := h.parsePagination(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	}
 
-	var afterID string
-	var afterCreatedAt *time.Time
-
-	if cursorStr != "" {
-		decoded, err := base64.StdEncoding.DecodeString(cursorStr)
-		if err == nil {
-			parts := strings.Split(string(decoded), "|")
-			if len(parts) == 2 {
-				ts, err := time.Parse(time.RFC3339, parts[0])
-				if err == nil {
-					afterCreatedAt = &ts
-					afterID = parts[1]
-				}
-			}
-		}
-	}
-
-	var slips []models.PaySlip
-	var total int
-	var err error
-	if isAdmin {
-		slips, total, err = h.PaySlipService.GetPaySlips(limit, afterID, afterCreatedAt)
-	} else {
-		slips, total, err = h.PaySlipService.GetPaySlipsByUserID(currentUser.ID, limit, afterID, afterCreatedAt)
-	}
-
+	slips, total, err := h.PaySlipService.GetPaySlipsByUserID(currentUser.ID, limit, afterID, afterCreatedAt)
 	if err != nil {
 		http.Error(w, "Failed to get pay slips", http.StatusInternalServerError)
 		return
 	}
 
-	// 2. Return clean paths only for the list (per latest PR review)
-	data := slips
-	if limit > 0 && len(slips) > limit {
-		data = slips[:limit]
+	h.respondWithPaySlips(w, slips, total, limit)
+}
+
+// GetAllPaySlips handles GET /api/pay-slips/all [admin only]
+func (h *Handler) GetAllPaySlips(w http.ResponseWriter, r *http.Request) {
+	currentUser := mustGetUser(r)
+	if currentUser == nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if currentUser.Role != string(constants.RoleAdmin) {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
 	}
 
-	var nextCursor *string
-	if limit > 0 && len(slips) > limit {
-		last := data[limit-1]
-		cursor := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s|%s", last.CreatedAt.Format(time.RFC3339), last.ID)))
-		nextCursor = &cursor
+	limit, afterID, afterCreatedAt, err := h.parsePagination(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	}
 
-	jsonResponse(w, http.StatusOK, models.PaySlipsResponse{
-		Data:       data,
-		Total:      total,
-		NextCursor: nextCursor,
-	})
+	// 2. Parse Filtering Params
+	userID := r.URL.Query().Get("userId")
+	yearStr := r.URL.Query().Get("year")
+	monthStr := r.URL.Query().Get("month")
+
+	var year, month int
+	if yearStr != "" {
+		var err error
+		year, err = strconv.Atoi(yearStr)
+		if err != nil {
+			http.Error(w, "Invalid year parameter: must be an integer", http.StatusBadRequest)
+			return
+		}
+	}
+	if monthStr != "" {
+		var err error
+		month, err = strconv.Atoi(monthStr)
+		if err != nil || month < 1 || month > 12 {
+			http.Error(w, "Invalid month parameter: must be between 1 and 12", http.StatusBadRequest)
+			return
+		}
+	}
+
+	slips, total, err := h.PaySlipService.GetPaySlips(limit, afterID, afterCreatedAt, userID, month, year)
+	if err != nil {
+		http.Error(w, "Failed to get pay slips", http.StatusInternalServerError)
+		return
+	}
+
+	h.respondWithPaySlips(w, slips, total, limit)
 }
 
 // GetPaySlipByID handles GET /api/pay-slips/{id}
@@ -240,4 +240,60 @@ func (h *Handler) DeletePaySlip(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// ── Private Helpers ──────────────────────────────────────────────────────────
+
+func (h *Handler) parsePagination(r *http.Request) (int, string, *time.Time, error) {
+	limitStr := r.URL.Query().Get("limit")
+	cursorStr := r.URL.Query().Get("cursor")
+
+	var limit int
+	if limitStr != "" {
+		var err error
+		limit, err = strconv.Atoi(limitStr)
+		if err != nil {
+			return 0, "", nil, fmt.Errorf("Invalid 'limit' parameter: must be an integer")
+		}
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 50 {
+		limit = 50
+	}
+
+	var afterID string
+	var afterCreatedAt *time.Time
+
+	if cursorStr != "" {
+		decoded, _ := base64.StdEncoding.DecodeString(cursorStr)
+		parts := strings.Split(string(decoded), "|")
+
+		if ts, err := time.Parse(time.RFC3339, parts[0]); err == nil && len(parts) == 2 {
+			afterCreatedAt = &ts
+			afterID = parts[1]
+		}
+	}
+	return limit, afterID, afterCreatedAt, nil
+}
+
+func (h *Handler) respondWithPaySlips(w http.ResponseWriter, slips []models.PaySlip, total int, limit int) {
+	data := slips
+	if limit > 0 && len(slips) > limit {
+		data = slips[:limit]
+	}
+
+	var nextCursor *string
+	if limit > 0 && len(slips) > limit {
+		last := data[limit-1]
+		cursor := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s|%s", last.CreatedAt.Format(time.RFC3339), last.ID)))
+		nextCursor = &cursor
+	}
+
+	jsonResponse(w, http.StatusOK, models.PaySlipsResponse{
+		Data:       data,
+		Total:      total,
+		NextCursor: nextCursor,
+	})
 }

--- a/pay-slip-app/backend/internal/services/payslip_service.go
+++ b/pay-slip-app/backend/internal/services/payslip_service.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"pay-slip-app/internal/database"
 	"pay-slip-app/internal/models"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -68,8 +69,29 @@ func (s *PaySlipService) GetPaySlipByUserMonthYear(userID string, month, year in
 	return ps, nil
 }
 
-func (s *PaySlipService) GetPaySlips(limit int, afterID string, afterCreatedAt *time.Time) ([]models.PaySlip, int, error) {
-	return s.fetchPaySlips("", nil, limit, afterID, afterCreatedAt)
+func (s *PaySlipService) GetPaySlips(limit int, afterID string, afterCreatedAt *time.Time, userID string, month, year int) ([]models.PaySlip, int, error) {
+	var whereParts []string
+	var args []interface{}
+
+	if userID != "" {
+		whereParts = append(whereParts, "user_id = ?")
+		args = append(args, userID)
+	}
+	if month > 0 {
+		whereParts = append(whereParts, "month = ?")
+		args = append(args, month)
+	}
+	if year > 0 {
+		whereParts = append(whereParts, "year = ?")
+		args = append(args, year)
+	}
+
+	whereClause := ""
+	if len(whereParts) > 0 {
+		whereClause = strings.Join(whereParts, " AND ")
+	}
+
+	return s.fetchPaySlips(whereClause, args, limit, afterID, afterCreatedAt)
 }
 
 func (s *PaySlipService) GetPaySlipsByUserID(userID string, limit int, afterID string, afterCreatedAt *time.Time) ([]models.PaySlip, int, error) {


### PR DESCRIPTION
# Description
This PR refactors the pay-slip retrieval logic by splitting the shared list endpoint into explicit role-specific paths and adds filtering capabilities for administrators.

## Key Changes
- **Split Endpoints**: Replaced role-dependent branching in `GET /api/pay-slips` with two distinct handlers:
    - GetMyPaySlips: Scoped to the authenticated user's own data.
    - GetAllPaySlips: Admin-only endpoint at `/api/pay-slips/all`.
- **Advanced Filtering**: Added support for `userId` , `year` and `month` query parameters on the admin list endpoint.
- **Service Layer Enhancements**: Refactored `PaySlipService.GetPaySlips` to use dynamic SQL `WHERE` clauses for flexible filtering.
- **OpenAPI Synchronization**: Updated api/openapi.yaml with the new routing structure, query parameters, and validation rules.

## Verification Results
- **Filtering**: Manually validated that slips are correctly filtered when providing `userId`, `year`, `mpnth` or all.

Closes #34 
Closes #36 
