### PR TITLE
fix(pay-slip)[backend]: add file type validation in UploadFile handler

### DIFF
--- a/pay-slip-app/backend/api/openapi.yaml
+++ b/pay-slip-app/backend/api/openapi.yaml
@@ -306,7 +306,7 @@ paths:
                 file:
                   type: string
                   format: binary
-                  description: PDF or Image (max 10MB)
+                  description: PDF or Image (.pdf, .png, .jpg, .jpeg) (max 10MB)
       responses:
         "200":
           description: Uploaded successfully

--- a/pay-slip-app/backend/internal/constants/constants.go
+++ b/pay-slip-app/backend/internal/constants/constants.go
@@ -8,6 +8,8 @@ const (
 	MaxUploadSizeMB = 10 // maximum allowed pay slip file size in megabytes
 )
 
+var AllowedExtensions = []string{".pdf", ".png", ".jpg", ".jpeg"}
+
 // Database / connection defaults (tweak according to your environment)
 const (
 	ConnMaxLifetimeMinutes = 5  // number of minutes before a connection is recycled

--- a/pay-slip-app/backend/internal/file/validator.go
+++ b/pay-slip-app/backend/internal/file/validator.go
@@ -1,0 +1,76 @@
+// internal/file/validator.go
+package file
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"pay-slip-app/internal/constants"
+)
+
+// mimeMapping provides a single source of truth for allowed extensions and their canonical MIME types
+var mimeMapping = map[string]string{
+	".pdf":  "application/pdf",
+	".png":  "image/png",
+	".jpg":  "image/jpeg",
+	".jpeg": "image/jpeg",
+}
+
+// GetAllowedExtensions returns a copy of the allowed file extensions for pay slips.
+func GetAllowedExtensions() []string {
+	// Return a copy to ensure immutability
+	extensions := make([]string, len(constants.AllowedExtensions))
+	copy(extensions, constants.AllowedExtensions)
+	return extensions
+}
+
+// GetAllowedExtensionsMap returns a map of allowed file extensions for efficient lookup.
+func GetAllowedExtensionsMap() map[string]struct{} {
+	m := make(map[string]struct{}, len(constants.AllowedExtensions))
+	for _, ext := range constants.AllowedExtensions {
+		m[ext] = struct{}{}
+	}
+	return m
+}
+
+// ValidatePaySlipFile validates the filename extension and the actual content (magic bytes).
+// It reads the first 512 bytes of the file and resets the file pointer using Seek.
+// Returns the detected MIME type and nil on success, or an error if invalid.
+func ValidatePaySlipFile(filename string, r io.ReadSeeker) (string, error) {
+	ext := strings.ToLower(filepath.Ext(filename))
+
+	// 1. Validate Extension against our known allowed list
+	canonicalMime, supported := mimeMapping[ext]
+	if !supported {
+		return "", fmt.Errorf("unsupported or invalid file extension: %s", ext)
+	}
+
+	// 2. Validate actual content for security
+	// http.DetectContentType uses the first 512 bytes to determine the MIME type.
+	buffer := make([]byte, 512)
+	n, err := r.Read(buffer)
+	if err != nil && err != io.EOF {
+		return "", fmt.Errorf("failed to read file for validation: %w", err)
+	}
+
+	// 3. Reset file pointer so subsequent reads (e.g., storage upload) start from the beginning.
+	if _, err := r.Seek(0, io.SeekStart); err != nil {
+		return "", fmt.Errorf("failed to reset file pointer: %w", err)
+	}
+
+	detectedMime := http.DetectContentType(buffer[:n])
+
+	// Clean detected MIME (remove charset info if present)
+	if parts := strings.Split(detectedMime, ";"); len(parts) > 0 {
+		detectedMime = parts[0]
+	}
+
+	// 4. Make sure the extension matches the actual content type
+	if detectedMime != canonicalMime {
+		return "", fmt.Errorf("file content (%s) does not match extension (%s)", detectedMime, ext)
+	}
+
+	return detectedMime, nil
+}

--- a/pay-slip-app/backend/internal/handlers/payslip_handlers.go
+++ b/pay-slip-app/backend/internal/handlers/payslip_handlers.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"pay-slip-app/internal/constants"
+	"pay-slip-app/internal/file"
 	"pay-slip-app/internal/models"
 	"pay-slip-app/internal/utils"
 	"strconv"
@@ -27,15 +29,22 @@ func (h *PaySlipHandler) UploadFile(w http.ResponseWriter, r *http.Request) {
 	// Enforce max upload size (10MB)
 	r.Body = http.MaxBytesReader(w, r.Body, int64(constants.MaxUploadSizeMB)<<20)
 
-	file, header, err := r.FormFile("file")
+	multipartFile, header, err := r.FormFile("file")
 	if err != nil {
 		http.Error(w, "file is required and must be under 10MB", http.StatusBadRequest)
 		return
 	}
-	defer file.Close()
+	defer multipartFile.Close()
+
+	// Use our dedicated file validator for security checks
+	contentType, err := file.ValidatePaySlipFile(header.Filename, multipartFile)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("%v. Allowed extensions: %s", err, strings.Join(file.GetAllowedExtensions(), ", ")), http.StatusBadRequest)
+		return
+	}
 
 	ctx := r.Context()
-	path, err := h.PaySlipService.UploadFile(ctx, file, header.Filename)
+	path, err := h.PaySlipService.UploadFile(ctx, multipartFile, header.Filename, contentType)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Failed to upload to storage: %v", err), http.StatusInternalServerError)
 		return

--- a/pay-slip-app/backend/internal/services/payslip_service.go
+++ b/pay-slip-app/backend/internal/services/payslip_service.go
@@ -29,8 +29,8 @@ func NewPaySlipService(db *database.Database, cfg configs.FirebaseConfig) (*PayS
 }
 
 // UploadFile proxies the storage upload operation.
-func (s *PaySlipService) UploadFile(ctx context.Context, file io.Reader, filename string) (string, error) {
-	return s.storage.UploadFile(ctx, file, filename)
+func (s *PaySlipService) UploadFile(ctx context.Context, file io.Reader, filename string, contentType string) (string, error) {
+	return s.storage.UploadFile(ctx, file, filename, contentType)
 }
 
 // GetSignedURL proxies the storage signed URL generation.

--- a/pay-slip-app/backend/internal/storage/storage.go
+++ b/pay-slip-app/backend/internal/storage/storage.go
@@ -68,13 +68,13 @@ func (s *FirebaseStorage) Close() error {
 }
 
 // UploadFile uploads a file to Firebase Storage and returns the clean storage path.
-func (s *FirebaseStorage) UploadFile(ctx context.Context, r io.Reader, originalFilename string) (string, error) {
+func (s *FirebaseStorage) UploadFile(ctx context.Context, r io.Reader, originalFilename string, contentType string) (string, error) {
 	ext := filepath.Ext(originalFilename)
 	objectPath := "pay-slips/" + uuid.New().String() + ext
 
 	wc := s.client.Bucket(s.bucket).Object(objectPath).NewWriter(ctx)
-	// Set Content-Type based on extension for better browser handling
-	wc.ContentType = s.getContentType(ext)
+	// Set Content-Type for better browser handling
+	wc.ContentType = contentType
 	
 	if _, err := io.Copy(wc, r); err != nil {
 		_ = wc.Close()
@@ -97,17 +97,4 @@ func (s *FirebaseStorage) DeleteFile(ctx context.Context, objectPath string) err
 		return fmt.Errorf("storage: failed to delete object %q: %w", objectPath, err)
 	}
 	return nil
-}
-
-func (s *FirebaseStorage) getContentType(ext string) string {
-	switch ext {
-	case ".pdf":
-		return "application/pdf"
-	case ".png":
-		return "image/png"
-	case ".jpg", ".jpeg":
-		return "image/jpeg"
-	default:
-		return "application/octet-stream"
-	}
 }


### PR DESCRIPTION
## Summary
This PR fixes the issue #30 by adding file type validation to the upload endpoint. The API now restricts uploads to supported formats to prevent invalid file associations.

## Changes
- **Validation**: Restricted uploads to `.pdf`, `.png`, `.jpg`, and `.jpeg` (case-insensitive).
- **Error Handling**: Non-supported types now return a `400 Bad Request`.
- **Docs**: Updated the OpenAPI spec to reflect supported formats.

## Verification
- [x] Verified supported formats upload correctly.
- [x] Verified unsupported formats are rejected with 400 error.

Closes #30 
