### PR TITLE
feat(pay-slip)[backend]: add paginated users endpoint v2 and refactor pagination

### DIFF
--- a/pay-slip-app/backend/api/openapi.yaml
+++ b/pay-slip-app/backend/api/openapi.yaml
@@ -100,6 +100,19 @@ components:
           type: string
           description: Base64 encoded cursor for the next page
 
+    UsersResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/User"
+        total:
+          type: integer
+        nextCursor:
+          type: string
+          description: Base64 encoded cursor for the next page
+
     CreatePaySlipRequest:
       type: object
       required: [userId, month, year, filePath]
@@ -208,6 +221,36 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/User"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /api/v2/users:
+    get:
+      tags: [Users]
+      summary: List all users with pagination [admin only]
+      description: Returns a paginated list of all users wrapped in an envelope.
+      parameters:
+        - name: limit
+          in: query
+          description: Max number of records to return (default 20, max 50)
+          schema:
+            type: integer
+            default: 20
+            maximum: 50
+        - name: cursor
+          in: query
+          description: Pagination cursor from previous response
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UsersResponse"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":

--- a/pay-slip-app/backend/cmd/main.go
+++ b/pay-slip-app/backend/cmd/main.go
@@ -52,6 +52,7 @@ func main() {
 	// User endpoints
 	mux.Handle("GET /api/me", auth(http.HandlerFunc(paySlipHandler.GetCurrentUser)))
 	mux.Handle("GET /api/users", auth(http.HandlerFunc(paySlipHandler.GetUsers)))
+	mux.Handle("GET /api/v2/users", auth(http.HandlerFunc(paySlipHandler.GetUsersV2)))
 	mux.Handle("PUT /api/users/{id}/role", auth(http.HandlerFunc(paySlipHandler.UpdateUserRole)))
 
 	// Pay slip endpoints

--- a/pay-slip-app/backend/internal/constants/constants.go
+++ b/pay-slip-app/backend/internal/constants/constants.go
@@ -1,12 +1,4 @@
-// internal/constants/constants.go
 package constants
-
-type Role string
-
-const (
-	RoleAdmin Role = "admin"
-	RoleUser  Role = "user"
-)
 
 const (
 	ContextUserKey = "user"

--- a/pay-slip-app/backend/internal/database/database.go
+++ b/pay-slip-app/backend/internal/database/database.go
@@ -100,6 +100,12 @@ func (db *Database) Query(query string, args ...any) (*sql.Rows, error) {
 	return conn.Query(query, args...)
 }
 
+func (db *Database) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+	return db.Conn.BeginTx(ctx, opts)
+}
+
 func (db *Database) QueryRow(query string, args ...any) *sql.Row {
 	db.mu.RLock()
 	conn := db.Conn
@@ -133,9 +139,9 @@ func (db *Database) Ping() error {
 }
 
 func (db *Database) Close() error {
-	db.mu.Lock()
+	db.mu.RLock()
 	conn := db.Conn
-	db.mu.Unlock()
+	db.mu.RUnlock()
 	return conn.Close()
 }
 
@@ -145,4 +151,3 @@ func (db *Database) Begin() (*sql.Tx, error) {
 	db.mu.RUnlock()
 	return conn.Begin()
 }
-

--- a/pay-slip-app/backend/internal/handlers/handlers.go
+++ b/pay-slip-app/backend/internal/handlers/handlers.go
@@ -37,4 +37,3 @@ func jsonResponse(w http.ResponseWriter, status int, data interface{}) {
 	w.WriteHeader(status)
 	json.NewEncoder(w).Encode(data)
 }
-

--- a/pay-slip-app/backend/internal/handlers/payslip_handlers.go
+++ b/pay-slip-app/backend/internal/handlers/payslip_handlers.go
@@ -1,15 +1,13 @@
 package handlers
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"pay-slip-app/internal/constants"
 	"pay-slip-app/internal/models"
+	"pay-slip-app/internal/utils"
 	"strconv"
-	"strings"
-	"time"
 )
 
 // ── PaySlip handlers ──────────────────────────────────────────────────────────
@@ -21,7 +19,7 @@ func (h *PaySlipHandler) UploadFile(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
-	if currentUser.Role != string(constants.RoleAdmin) {
+	if currentUser.Role != models.UserRoleAdmin {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}
@@ -53,7 +51,7 @@ func (h *PaySlipHandler) CreatePaySlip(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
-	if currentUser.Role != string(constants.RoleAdmin) {
+	if currentUser.Role != models.UserRoleAdmin {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}
@@ -128,7 +126,7 @@ func (h *PaySlipHandler) GetMyPaySlips(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	limit, afterID, afterCreatedAt, err := h.parsePagination(r)
+	limit, afterID, afterCreatedAt, err := utils.ParsePagination(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -150,12 +148,12 @@ func (h *PaySlipHandler) GetAllPaySlips(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
-	if currentUser.Role != string(constants.RoleAdmin) {
+	if currentUser.Role != models.UserRoleAdmin {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}
 
-	limit, afterID, afterCreatedAt, err := h.parsePagination(r)
+	limit, afterID, afterCreatedAt, err := utils.ParsePagination(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -207,7 +205,7 @@ func (h *PaySlipHandler) GetPaySlipByID(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if currentUser.Role != string(constants.RoleAdmin) && ps.UserID != currentUser.ID {
+	if currentUser.Role != models.UserRoleAdmin && ps.UserID != currentUser.ID {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}
@@ -228,7 +226,7 @@ func (h *PaySlipHandler) DeletePaySlip(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
-	if currentUser.Role != string(constants.RoleAdmin) {
+	if currentUser.Role != models.UserRoleAdmin {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}
@@ -243,55 +241,14 @@ func (h *PaySlipHandler) DeletePaySlip(w http.ResponseWriter, r *http.Request) {
 
 // ── Private Helpers ──────────────────────────────────────────────────────────
 
-func (h *PaySlipHandler) parsePagination(r *http.Request) (int, string, *time.Time, error) {
-	limitStr := r.URL.Query().Get("limit")
-	cursorStr := r.URL.Query().Get("cursor")
-
-	var limit int
-	if limitStr != "" {
-		var err error
-		limit, err = strconv.Atoi(limitStr)
-		if err != nil {
-			return 0, "", nil, fmt.Errorf("Invalid 'limit' parameter: must be an integer")
-		}
-	}
-	if limit <= 0 {
-		limit = 20
-	}
-	if limit > 50 {
-		limit = 50
-	}
-
-	var afterID string
-	var afterCreatedAt *time.Time
-
-	if cursorStr != "" {
-		decoded, _ := base64.StdEncoding.DecodeString(cursorStr)
-		parts := strings.Split(string(decoded), "|")
-
-		if len(parts) != 2 {
-			return 0, "", nil, fmt.Errorf("invalid cursor format")
-		}
-
-		if ts, err := time.Parse(time.RFC3339, parts[0]); err == nil {
-			afterCreatedAt = &ts
-			afterID = parts[1]
-		}
-	}
-	return limit, afterID, afterCreatedAt, nil
-}
 
 func (h *PaySlipHandler) respondWithPaySlips(w http.ResponseWriter, slips []models.PaySlip, total int, limit int) {
 	data := slips
-	if limit > 0 && len(slips) > limit {
-		data = slips[:limit]
-	}
-
 	var nextCursor *string
 	if limit > 0 && len(slips) > limit {
+		data = slips[:limit]
 		last := data[limit-1]
-		cursor := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s|%s", last.CreatedAt.Format(time.RFC3339), last.ID)))
-		nextCursor = &cursor
+		nextCursor = utils.EncodeCursor(last.CreatedAt, last.ID)
 	}
 
 	jsonResponse(w, http.StatusOK, models.PaySlipsResponse{

--- a/pay-slip-app/backend/internal/handlers/user_handlers.go
+++ b/pay-slip-app/backend/internal/handlers/user_handlers.go
@@ -3,8 +3,8 @@ package handlers
 import (
 	"encoding/json"
 	"net/http"
-	"pay-slip-app/internal/constants"
 	"pay-slip-app/internal/models"
+	"pay-slip-app/internal/utils"
 )
 
 // ── User handlers ─────────────────────────────────────────────────────────────
@@ -26,7 +26,7 @@ func (h *PaySlipHandler) GetUsers(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
-	if currentUser.Role != string(constants.RoleAdmin) {
+	if currentUser.Role != models.UserRoleAdmin {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}
@@ -38,6 +38,45 @@ func (h *PaySlipHandler) GetUsers(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, http.StatusOK, users)
 }
 
+// GetUsersV2 handles GET /api/v2/users  [admin only]
+func (h *PaySlipHandler) GetUsersV2(w http.ResponseWriter, r *http.Request) {
+	currentUser := mustGetUser(r)
+	if currentUser == nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if currentUser.Role != models.UserRoleAdmin {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
+	limit, afterID, afterCreatedAt, err := utils.ParsePagination(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	users, total, err := h.UserService.GetUsers(limit, afterID, afterCreatedAt)
+	if err != nil {
+		http.Error(w, "Failed to get users", http.StatusInternalServerError)
+		return
+	}
+
+	data := users
+	var nextCursor *string
+	if limit > 0 && len(users) > limit {
+		data = users[:limit]
+		last := data[limit-1]
+		nextCursor = utils.EncodeCursor(last.CreatedAt, last.ID)
+	}
+
+	jsonResponse(w, http.StatusOK, models.UsersResponse{
+		Data:       data,
+		Total:      total,
+		NextCursor: nextCursor,
+	})
+}
+
 // UpdateUserRole handles PUT /api/users/{id}/role  [admin only]
 func (h *PaySlipHandler) UpdateUserRole(w http.ResponseWriter, r *http.Request) {
 	currentUser := mustGetUser(r)
@@ -45,7 +84,7 @@ func (h *PaySlipHandler) UpdateUserRole(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
-	if currentUser.Role != string(constants.RoleAdmin) {
+	if currentUser.Role != models.UserRoleAdmin {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}

--- a/pay-slip-app/backend/internal/models/models.go
+++ b/pay-slip-app/backend/internal/models/models.go
@@ -3,17 +3,23 @@ package models
 
 import (
 	"errors"
-	"pay-slip-app/internal/constants"
 	"strings"
 	"time"
 )
 
+// UserRole represents the access level of a user.
+type UserRole string
+
+const (
+	UserRoleAdmin UserRole = "admin"
+	UserRoleUser  UserRole = "user"
+)
+
 // User represents an authenticated employee in the system.
-// ... (User struct remains the same)
 type User struct {
 	ID        string    `json:"id"`
 	Email     string    `json:"email"`
-	Role      string    `json:"role"`
+	Role      UserRole  `json:"role"`
 	CreatedAt time.Time `json:"-"`
 }
 
@@ -36,6 +42,13 @@ type PaySlipsResponse struct {
 	Data       []PaySlip `json:"data"`
 	Total      int       `json:"total"`
 	NextCursor *string   `json:"nextCursor"`
+}
+
+// UsersResponse is the unified response for GET /api/v2/users.
+type UsersResponse struct {
+	Data       []User  `json:"data"`
+	Total      int     `json:"total"`
+	NextCursor *string `json:"nextCursor"`
 }
 
 // CreatePaySlipRequest is the JSON body for POST /api/pay-slips.
@@ -67,11 +80,11 @@ func (r *CreatePaySlipRequest) Validate() error {
 
 // UpdateUserRoleRequest is used by PUT /api/users/:id/role.
 type UpdateUserRoleRequest struct {
-	Role string `json:"role"`
+	Role UserRole `json:"role"`
 }
 
 func (r *UpdateUserRoleRequest) Validate() error {
-	if r.Role != string(constants.RoleAdmin) && r.Role != string(constants.RoleUser) {
+	if r.Role != UserRoleAdmin && r.Role != UserRoleUser {
 		return errors.New("role must be either 'admin' or 'user'")
 	}
 	return nil

--- a/pay-slip-app/backend/internal/services/payslip_service.go
+++ b/pay-slip-app/backend/internal/services/payslip_service.go
@@ -218,13 +218,6 @@ func (s *PaySlipService) fetchPaySlips(whereClause string, args []interface{}, l
 
 	query += " ORDER BY created_at DESC, id DESC"
 
-	const maxLimit = 100
-	if limit <= 0 {
-		limit = 10 // default limit
-	}
-	if limit > maxLimit {
-		limit = maxLimit
-	}
 	query += " LIMIT ?"
 	args = append(args, limit+1)
 

--- a/pay-slip-app/backend/internal/services/user_service.go
+++ b/pay-slip-app/backend/internal/services/user_service.go
@@ -1,9 +1,12 @@
 package services
 
 import (
-	"pay-slip-app/internal/constants"
+	"context"
+	"database/sql"
+	"fmt"
 	"pay-slip-app/internal/database"
 	"pay-slip-app/internal/models"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -40,7 +43,7 @@ func (s *UserService) CreateUser(email string) (*models.User, error) {
 	user := &models.User{
 		ID:    uuid.New().String(),
 		Email: email,
-		Role:  string(constants.RoleUser),
+		Role:  models.UserRoleUser,
 	}
 	query := "INSERT INTO users (id, email, role) VALUES (?, ?, ?)"
 	if _, err := s.db.Exec(query, user.ID, user.Email, user.Role); err != nil {
@@ -67,7 +70,62 @@ func (s *UserService) GetAllUsers() ([]models.User, error) {
 	return users, nil
 }
 
-func (s *UserService) UpdateUserRole(userID string, role string) error {
+func (s *UserService) GetUsers(limit int, afterID string, afterCreatedAt *time.Time) ([]models.User, int, error) {
+	// Start a transaction to ensure Total and Select see the same snapshot of data
+	tx, err := s.db.BeginTx(context.Background(), &sql.TxOptions{
+		Isolation: sql.LevelRepeatableRead,
+		ReadOnly:  true,
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	defer tx.Rollback() // Ensures resources are freed if we return early
+
+	// 1. Get Total Count
+	var total int
+	err = tx.QueryRow("SELECT COUNT(*) FROM users").Scan(&total)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to count users: %w", err)
+	}
+
+	// 2. Fetch Paginated Data
+	query := "SELECT id, email, role, created_at FROM users"
+	var args []interface{}
+
+	if afterCreatedAt != nil && afterID != "" {
+		query += " WHERE (created_at < ? OR (created_at = ? AND id < ?))"
+		args = append(args, afterCreatedAt, afterCreatedAt, afterID)
+	}
+
+	query += " ORDER BY created_at DESC, id DESC"
+
+	query += " LIMIT ?"
+	args = append(args, limit+1)
+
+	rows, err := tx.Query(query, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to fetch users: %w", err)
+	}
+	defer rows.Close()
+
+	users := make([]models.User, 0, limit)
+	for rows.Next() {
+		var u models.User
+		if err := rows.Scan(&u.ID, &u.Email, &u.Role, &u.CreatedAt); err != nil {
+			return nil, 0, err
+		}
+		users = append(users, u)
+	}
+
+	// Commit the transaction
+	if err := tx.Commit(); err != nil {
+		return nil, 0, err
+	}
+
+	return users, total, nil
+}
+
+func (s *UserService) UpdateUserRole(userID string, role models.UserRole) error {
 	_, err := s.db.Exec("UPDATE users SET role = ? WHERE id = ?", role, userID)
 	return err
 }

--- a/pay-slip-app/backend/internal/utils/pagination.go
+++ b/pay-slip-app/backend/internal/utils/pagination.go
@@ -1,0 +1,64 @@
+package utils
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultLimit = 20
+	MaxLimit     = 50
+)
+
+// ParsePagination parses limit and cursor from the request.
+// The cursor is expected to be a base64 encoded string of "timestamp|id".
+func ParsePagination(r *http.Request) (limit int, afterID string, afterCreatedAt *time.Time, err error) {
+	limitStr := r.URL.Query().Get("limit")
+	cursorStr := r.URL.Query().Get("cursor")
+
+	if limitStr != "" {
+		limit, err = strconv.Atoi(limitStr)
+		if err != nil {
+			return 0, "", nil, fmt.Errorf("invalid 'limit' parameter: must be an integer")
+		}
+	}
+	if limit <= 0 {
+		limit = DefaultLimit
+	}
+	if limit > MaxLimit {
+		limit = MaxLimit
+	}
+
+	if cursorStr != "" {
+		decoded, err := base64.StdEncoding.DecodeString(cursorStr)
+		if err != nil {
+			return 0, "", nil, fmt.Errorf("invalid 'cursor' parameter: not a valid base64 string")
+		}
+
+		parts := strings.Split(string(decoded), "|")
+		if len(parts) != 2 {
+			return 0, "", nil, fmt.Errorf("invalid 'cursor' parameter: incorrect format")
+		}
+
+		ts, err := time.Parse(time.RFC3339, parts[0])
+		if err != nil {
+			return 0, "", nil, fmt.Errorf("invalid 'cursor' parameter: invalid timestamp")
+		}
+
+		afterCreatedAt = &ts
+		afterID = parts[1]
+	}
+
+	return limit, afterID, afterCreatedAt, nil
+}
+
+// EncodeCursor creates a base64 encoded cursor from a timestamp and an ID.
+func EncodeCursor(createdAt time.Time, id string) *string {
+	payload := fmt.Sprintf("%s|%s", createdAt.Format(time.RFC3339), id)
+	encoded := base64.StdEncoding.EncodeToString([]byte(payload))
+	return &encoded
+}


### PR DESCRIPTION
#### Summary
This PR introduces a new version of the users listing endpoint (`GET /api/v2/users`) with cursor-based pagination and a consistent envelope response. This PR also centralizes pagination parsing to reduce code duplication.

#### Technical Changes
- **New Endpoint**: Added a versioned users endpoint to support pagination without breaking the current frontend.
- **Shared Logic**: Refactored pagination parameter parsing into the base handler for cross-module use.
- **Data Layer**: Updated the service layer to support paginated user queries and total count retrieval.
- **Documentation**: Updated the OpenAPI specification with the new schema and route.

#### Verification
- Confirmed backward compatibility of the legacy users endpoint.

Closes #32  
