### PR TITLE
[ResourceApp][Backend][Feat] Implement Resource-Permission Endpoints

### DIFF
--- a/resource-app/backend/cmd/server/main.go
+++ b/resource-app/backend/cmd/server/main.go
@@ -17,6 +17,7 @@ import (
 	"resource-app/internal/config"
 	"resource-app/internal/db"
 	"resource-app/internal/group"
+	"resource-app/internal/permission"
 	"resource-app/internal/resource"
 	"resource-app/internal/user"
 )
@@ -76,6 +77,11 @@ func main() {
 	// Initialize group service
 	groupService := group.NewService(groupRepo)
 
+	// Initialize permission repository
+	permissionRepo := permission.NewGormRepository(database)
+	// Initialize permission service
+	permissionService := permission.NewService(permissionRepo)
+
 
 	// Create Gin router
 	r := gin.Default()
@@ -114,6 +120,13 @@ func main() {
 	apiGroup.GET("/groups/:id/users", group.HandleGetGroupMembers(groupService))
 	apiGroup.POST("/groups/:id/users", group.HandleAddUsersToGroup(groupService))
 	apiGroup.DELETE("/groups/:id/users/:userId", group.HandleRemoveUserFromGroup(groupService))
+	// Group permissions
+	apiGroup.POST("/resource-permissions", permission.HandleCreatePermission(permissionService))
+	apiGroup.PATCH("/resource-permissions/:id", permission.HandleUpdatePermissionType(permissionService))
+	apiGroup.DELETE("/resource-permissions/:id", permission.HandleDeletePermission(permissionService))
+	apiGroup.GET("/groups/:id/permissions", permission.HandleGetGroupPermissions(permissionService))
+
+
 
 	// Resources
 	apiGroup.GET("/resources", resource.HandleGetResources(resourceService))

--- a/resource-app/backend/internal/booking/models.go
+++ b/resource-app/backend/internal/booking/models.go
@@ -13,9 +13,11 @@ type Booking struct {
 	Start           time.Time       `json:"start" gorm:"not null"`
 	End             time.Time       `json:"end" gorm:"not null"`
 	Status          BookingStatus   `json:"status" gorm:"index;type:varchar(20);default:'pending'"`
-	CreatedAt       time.Time       `json:"createdAt" gorm:"autoCreateTime"`
 	RejectionReason *string         `json:"rejectionReason,omitempty" gorm:"type:text"`
 	Details         json.RawMessage `json:"details" gorm:"type:json"` // Stored as JSON
+	CreatedAt       time.Time       `json:"createdAt" gorm:"autoCreateTime"`
+	UpdatedAt       time.Time       `json:"updatedAt" gorm:"autoUpdateTime"`
+	
 }
 
 //Stats

--- a/resource-app/backend/internal/db/db.go
+++ b/resource-app/backend/internal/db/db.go
@@ -9,6 +9,7 @@ import (
 	"resource-app/internal/group"
 	"resource-app/internal/resource"
 	"resource-app/internal/user"
+	"resource-app/internal/permission"
 
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"

--- a/resource-app/backend/internal/db/db.go
+++ b/resource-app/backend/internal/db/db.go
@@ -26,7 +26,7 @@ func NewDatabase(dsn string) (*gorm.DB, error) {
 	}
 
 	// Auto-migrate models
-	if err := db.AutoMigrate(&user.User{}, &resource.Resource{}, &booking.Booking{}, &group.Group{}, &group.UserGroup{}); err != nil {
+	if err := db.AutoMigrate(&user.User{}, &resource.Resource{}, &booking.Booking{}, &group.Group{}, &group.UserGroup{}, &permission.ResourcePermission{}); err != nil {
 		return nil, err
 	}
 

--- a/resource-app/backend/internal/group/models.go
+++ b/resource-app/backend/internal/group/models.go
@@ -11,9 +11,11 @@ type Group struct {
 }
 
 type UserGroup struct {
-	ID      string `json:"id" gorm:"type:varchar(36);primaryKey"`
-	UserID  string `json:"userId" gorm:"column:user_id;type:varchar(36);not null;index"`
-	GroupID string `json:"groupId" gorm:"column:group_id;type:varchar(36);not null;index"`
+	ID        string    `json:"id" gorm:"type:varchar(36);primaryKey"`
+	UserID    string    `json:"userId" gorm:"column:user_id;type:varchar(36);not null;index"`
+	GroupID   string    `json:"groupId" gorm:"column:group_id;type:varchar(36);not null;index"`
+	CreatedAt time.Time `json:"createdAt" gorm:"autoCreateTime"`
+	UpdatedAt time.Time `json:"updatedAt" gorm:"autoUpdateTime"`
 }
 
 type CreateAndUpdateGroupPayload struct {

--- a/resource-app/backend/internal/permission/constants.go
+++ b/resource-app/backend/internal/permission/constants.go
@@ -12,7 +12,7 @@ const (
 
 var (
 	ErrPermissionNotFound    = errors.New("permission not found")
-	ErrPermissionConflict    = errors.New("permission already exists for this group and resource")
+	ErrPermissionConflict    = errors.New("permission type already exists for this group and resource")
 	ErrInvalidPermissionType = errors.New("invalid permission type")
 	ErrGroupNotFound         = errors.New("group not found")
 	ErrResourceNotFound      = errors.New("resource not found")

--- a/resource-app/backend/internal/permission/constants.go
+++ b/resource-app/backend/internal/permission/constants.go
@@ -1,0 +1,28 @@
+package permission
+
+import "errors"
+
+// PermissionType represents permission level assigned to a group for a resource.
+type PermissionType string
+
+const (
+	PermissionTypeRequest PermissionType = "REQUEST"
+	PermissionTypeApprove PermissionType = "APPROVE"
+)
+
+var (
+	ErrPermissionNotFound    = errors.New("permission not found")
+	ErrPermissionConflict    = errors.New("permission already exists for this group and resource")
+	ErrInvalidPermissionType = errors.New("invalid permission type")
+	ErrGroupNotFound         = errors.New("group not found")
+	ErrResourceNotFound      = errors.New("resource not found")
+)
+
+func IsValidPermissionType(permissionType PermissionType) bool {
+	switch permissionType {
+	case PermissionTypeRequest, PermissionTypeApprove:
+		return true
+	default:
+		return false
+	}
+}

--- a/resource-app/backend/internal/permission/handlers.go
+++ b/resource-app/backend/internal/permission/handlers.go
@@ -1,11 +1,9 @@
 package permission
 
 import (
-	"errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 )
 
 func HandleCreatePermission(svc *Service) gin.HandlerFunc {
@@ -16,16 +14,6 @@ func HandleCreatePermission(svc *Service) gin.HandlerFunc {
 			return
 		}
 
-		if _, err := uuid.Parse(req.ResourceID); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid resource ID"})
-			return
-		}
-
-		if _, err := uuid.Parse(req.GroupID); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid group ID"})
-			return
-		}
-
 		permission := ResourcePermission{
 			ResourceID:     req.ResourceID,
 			GroupID:        req.GroupID,
@@ -33,16 +21,8 @@ func HandleCreatePermission(svc *Service) gin.HandlerFunc {
 		}
 
 		if err := svc.CreatePermission(&permission); err != nil {
-			switch {
-			case errors.Is(err, ErrInvalidPermissionType):
-				c.JSON(http.StatusBadRequest, gin.H{"error": ErrInvalidPermissionType.Error()})
-			case errors.Is(err, ErrResourceNotFound), errors.Is(err, ErrGroupNotFound):
-				c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
-			case errors.Is(err, ErrPermissionConflict):
-				c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
-			default:
-				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create permission"})
-			}
+			statusCode, responseBody := mapPermissionErrorToResponse(err, "Failed to create permission")
+			c.JSON(statusCode, responseBody)
 			return
 		}
 
@@ -53,10 +33,6 @@ func HandleCreatePermission(svc *Service) gin.HandlerFunc {
 func HandleUpdatePermissionType(svc *Service) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		id := c.Param("id")
-		if _, err := uuid.Parse(id); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid permission ID"})
-			return
-		}
 
 		var req UpdatePermissionTypeRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
@@ -66,16 +42,8 @@ func HandleUpdatePermissionType(svc *Service) gin.HandlerFunc {
 
 		updated, err := svc.UpdatePermissionType(id, req.PermissionType)
 		if err != nil {
-			switch {
-			case errors.Is(err, ErrInvalidPermissionType):
-				c.JSON(http.StatusBadRequest, gin.H{"error": ErrInvalidPermissionType.Error()})
-			case errors.Is(err, ErrPermissionNotFound):
-				c.JSON(http.StatusNotFound, gin.H{"error": ErrPermissionNotFound.Error()})
-			case errors.Is(err, ErrPermissionConflict):
-				c.JSON(http.StatusConflict, gin.H{"error": ErrPermissionConflict.Error()})
-			default:
-				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update permission"})
-			}
+			statusCode, responseBody := mapPermissionErrorToResponse(err, "Failed to update permission")
+			c.JSON(statusCode, responseBody)
 			return
 		}
 
@@ -86,18 +54,10 @@ func HandleUpdatePermissionType(svc *Service) gin.HandlerFunc {
 func HandleDeletePermission(svc *Service) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		id := c.Param("id")
-		if _, err := uuid.Parse(id); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid permission ID"})
-			return
-		}
 
 		if err := svc.DeletePermission(id); err != nil {
-			switch {
-			case errors.Is(err, ErrPermissionNotFound):
-				c.JSON(http.StatusNotFound, gin.H{"error": ErrPermissionNotFound.Error()})
-			default:
-				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete permission"})
-			}
+			statusCode, responseBody := mapPermissionErrorToResponse(err, "Failed to delete permission")
+			c.JSON(statusCode, responseBody)
 			return
 		}
 
@@ -108,19 +68,11 @@ func HandleDeletePermission(svc *Service) gin.HandlerFunc {
 func HandleGetGroupPermissions(svc *Service) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		groupID := c.Param("id")
-		if _, err := uuid.Parse(groupID); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid group ID"})
-			return
-		}
 
 		permissions, err := svc.GetPermissionsByGroupID(groupID)
 		if err != nil {
-			switch {
-			case errors.Is(err, ErrGroupNotFound):
-				c.JSON(http.StatusNotFound, gin.H{"error": ErrGroupNotFound.Error()})
-			default:
-				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch group permissions"})
-			}
+			statusCode, responseBody := mapPermissionErrorToResponse(err, "Failed to fetch group permissions")
+			c.JSON(statusCode, responseBody)
 			return
 		}
 

--- a/resource-app/backend/internal/permission/handlers.go
+++ b/resource-app/backend/internal/permission/handlers.go
@@ -1,0 +1,129 @@
+package permission
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+func HandleCreatePermission(svc *Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req CreatePermissionRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		if _, err := uuid.Parse(req.ResourceID); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid resource ID"})
+			return
+		}
+
+		if _, err := uuid.Parse(req.GroupID); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid group ID"})
+			return
+		}
+
+		permission := ResourcePermission{
+			ResourceID:     req.ResourceID,
+			GroupID:        req.GroupID,
+			PermissionType: req.PermissionType,
+		}
+
+		if err := svc.CreatePermission(&permission); err != nil {
+			switch {
+			case errors.Is(err, ErrInvalidPermissionType):
+				c.JSON(http.StatusBadRequest, gin.H{"error": ErrInvalidPermissionType.Error()})
+			case errors.Is(err, ErrResourceNotFound), errors.Is(err, ErrGroupNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+			case errors.Is(err, ErrPermissionConflict):
+				c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
+			default:
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create permission"})
+			}
+			return
+		}
+
+		c.JSON(http.StatusCreated, gin.H{"success": true, "data": permission})
+	}
+}
+
+func HandleUpdatePermissionType(svc *Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		id := c.Param("id")
+		if _, err := uuid.Parse(id); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid permission ID"})
+			return
+		}
+
+		var req UpdatePermissionTypeRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		updated, err := svc.UpdatePermissionType(id, req.PermissionType)
+		if err != nil {
+			switch {
+			case errors.Is(err, ErrInvalidPermissionType):
+				c.JSON(http.StatusBadRequest, gin.H{"error": ErrInvalidPermissionType.Error()})
+			case errors.Is(err, ErrPermissionNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": ErrPermissionNotFound.Error()})
+			case errors.Is(err, ErrPermissionConflict):
+				c.JSON(http.StatusConflict, gin.H{"error": ErrPermissionConflict.Error()})
+			default:
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update permission"})
+			}
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"success": true, "data": updated})
+	}
+}
+
+func HandleDeletePermission(svc *Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		id := c.Param("id")
+		if _, err := uuid.Parse(id); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid permission ID"})
+			return
+		}
+
+		if err := svc.DeletePermission(id); err != nil {
+			switch {
+			case errors.Is(err, ErrPermissionNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": ErrPermissionNotFound.Error()})
+			default:
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete permission"})
+			}
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"success": true, "data": true})
+	}
+}
+
+func HandleGetGroupPermissions(svc *Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		groupID := c.Param("id")
+		if _, err := uuid.Parse(groupID); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid group ID"})
+			return
+		}
+
+		permissions, err := svc.GetPermissionsByGroupID(groupID)
+		if err != nil {
+			switch {
+			case errors.Is(err, ErrGroupNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": ErrGroupNotFound.Error()})
+			default:
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch group permissions"})
+			}
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"success": true, "data": permissions})
+	}
+}

--- a/resource-app/backend/internal/permission/models.go
+++ b/resource-app/backend/internal/permission/models.go
@@ -8,6 +8,7 @@ type ResourcePermission struct {
 	GroupID        string         `json:"groupId" gorm:"column:group_id;type:varchar(36);not null;index"`
 	PermissionType PermissionType `json:"permissionType" gorm:"column:permission_type;type:varchar(20);not null"`
 	CreatedAt      time.Time      `json:"createdAt" gorm:"autoCreateTime"`
+	UpdatedAt      time.Time      `json:"updatedAt" gorm:"autoUpdateTime"`
 }
 
 func (ResourcePermission) TableName() string {

--- a/resource-app/backend/internal/permission/models.go
+++ b/resource-app/backend/internal/permission/models.go
@@ -1,0 +1,32 @@
+package permission
+
+import "time"
+
+type ResourcePermission struct {
+	ID             string         `json:"id" gorm:"primaryKey;type:varchar(36)"`
+	ResourceID     string         `json:"resourceId" gorm:"column:resource_id;type:varchar(36);not null;index"`
+	GroupID        string         `json:"groupId" gorm:"column:group_id;type:varchar(36);not null;index"`
+	PermissionType PermissionType `json:"permissionType" gorm:"column:permission_type;type:varchar(20);not null"`
+	CreatedAt      time.Time      `json:"createdAt" gorm:"autoCreateTime"`
+}
+
+func (ResourcePermission) TableName() string {
+	return "resource_permissions"
+}
+
+type CreatePermissionRequest struct {
+	ResourceID     string         `json:"resourceId" binding:"required"`
+	GroupID        string         `json:"groupId" binding:"required"`
+	PermissionType PermissionType `json:"permissionType" binding:"required"`
+}
+
+type UpdatePermissionTypeRequest struct {
+	PermissionType PermissionType `json:"permissionType" binding:"required"`
+}
+
+type GroupPermissionResult struct {
+	ID             string         `json:"id"`
+	ResourceID     string         `json:"resourceId" gorm:"column:resource_id"`
+	ResourceName   string         `json:"resourceName" gorm:"column:resource_name"`
+	PermissionType PermissionType `json:"permissionType" gorm:"column:permission_type"`
+}

--- a/resource-app/backend/internal/permission/repository.go
+++ b/resource-app/backend/internal/permission/repository.go
@@ -23,30 +23,32 @@ func NewGormRepository(db *gorm.DB) *GormRepository {
 }
 
 func (r *GormRepository) CreatePermission(permission *ResourcePermission) error {
-	var resourceCount int64
-	if err := r.db.Table("resources").Where("id = ?", permission.ResourceID).Count(&resourceCount).Error; err != nil {
-		return err
-	}
-	if resourceCount == 0 {
-		return ErrResourceNotFound
-	}
-
-	var groupCount int64
-	if err := r.db.Table("groups").Where("id = ?", permission.GroupID).Count(&groupCount).Error; err != nil {
-		return err
-	}
-	if groupCount == 0 {
-		return ErrGroupNotFound
-	}
-
-	if err := r.db.Create(permission).Error; err != nil {
-		if isDuplicateKeyError(err) {
-			return ErrPermissionConflict
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		var resourceCount int64
+		if err := tx.Table("resources").Where("id = ?", permission.ResourceID).Count(&resourceCount).Error; err != nil {
+			return err
 		}
-		return err
-	}
+		if resourceCount == 0 {
+			return ErrResourceNotFound
+		}
 
-	return nil
+		var groupCount int64
+		if err := tx.Table("groups").Where("id = ?", permission.GroupID).Count(&groupCount).Error; err != nil {
+			return err
+		}
+		if groupCount == 0 {
+			return ErrGroupNotFound
+		}
+
+		if err := tx.Create(permission).Error; err != nil {
+			if isDuplicateKeyError(err) {
+				return ErrPermissionConflict
+			}
+			return err
+		}
+
+		return nil
+	})
 }
 
 func (r *GormRepository) UpdatePermissionType(id string, permissionType PermissionType) (*ResourcePermission, error) {
@@ -58,8 +60,8 @@ func (r *GormRepository) UpdatePermissionType(id string, permissionType Permissi
 		return nil, err
 	}
 
-	if existing.PermissionType == permissionType {
-		return nil, ErrPermissionConflict
+	if existing.PermissionType == permissionType {  
+		return &existing, nil
 	}
 
 	result := r.db.Model(&ResourcePermission{}).
@@ -77,15 +79,8 @@ func (r *GormRepository) UpdatePermissionType(id string, permissionType Permissi
 		return nil, ErrPermissionNotFound
 	}
 
-	var updated ResourcePermission
-	if err := r.db.First(&updated, "id = ?", id).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
-			return nil, ErrPermissionNotFound
-		}
-		return nil, err
-	}
-
-	return &updated, nil
+	existing.PermissionType = permissionType
+	return &existing, nil
 }
 
 func (r *GormRepository) DeletePermission(id string) error {
@@ -102,22 +97,24 @@ func (r *GormRepository) DeletePermission(id string) error {
 }
 
 func (r *GormRepository) GetPermissionsByGroupID(groupID string) ([]GroupPermissionResult, error) {
-	var groupCount int64
-	if err := r.db.Table("groups").Where("id = ?", groupID).Count(&groupCount).Error; err != nil {
-		return nil, err
-	}
-	if groupCount == 0 {
-		return nil, ErrGroupNotFound
-	}
-
 	var permissions []GroupPermissionResult
-	err := r.db.Table("resource_permissions rp").
-		Select("rp.id, rp.resource_id, r.name AS resource_name, rp.permission_type").
-		Joins("JOIN resources r ON r.id = rp.resource_id").
-		Where("rp.group_id = ?", groupID).
-		Order("r.name ASC").
-		Order("rp.permission_type ASC").
-		Scan(&permissions).Error
+	err := r.db.Transaction(func(tx *gorm.DB) error {
+		var groupCount int64
+		if err := tx.Table("groups").Where("id = ?", groupID).Count(&groupCount).Error; err != nil {
+			return err
+		}
+		if groupCount == 0 {
+			return ErrGroupNotFound
+		}
+
+		return tx.Table("resource_permissions rp").
+			Select("rp.id, rp.resource_id, r.name AS resource_name, rp.permission_type").
+			Joins("JOIN resources r ON r.id = rp.resource_id").
+			Where("rp.group_id = ?", groupID).
+			Order("r.name ASC").
+			Order("rp.permission_type ASC").
+			Scan(&permissions).Error
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/resource-app/backend/internal/permission/repository.go
+++ b/resource-app/backend/internal/permission/repository.go
@@ -1,0 +1,134 @@
+package permission
+
+import (
+	"strings"
+
+	mysqlDriver "github.com/go-sql-driver/mysql"
+	"gorm.io/gorm"
+)
+
+type Repository interface {
+	CreatePermission(permission *ResourcePermission) error
+	UpdatePermissionType(id string, permissionType PermissionType) (*ResourcePermission, error)
+	DeletePermission(id string) error
+	GetPermissionsByGroupID(groupID string) ([]GroupPermissionResult, error)
+}
+
+type GormRepository struct {
+	db *gorm.DB
+}
+
+func NewGormRepository(db *gorm.DB) *GormRepository {
+	return &GormRepository{db: db}
+}
+
+func (r *GormRepository) CreatePermission(permission *ResourcePermission) error {
+	var resourceCount int64
+	if err := r.db.Table("resources").Where("id = ?", permission.ResourceID).Count(&resourceCount).Error; err != nil {
+		return err
+	}
+	if resourceCount == 0 {
+		return ErrResourceNotFound
+	}
+
+	var groupCount int64
+	if err := r.db.Table("groups").Where("id = ?", permission.GroupID).Count(&groupCount).Error; err != nil {
+		return err
+	}
+	if groupCount == 0 {
+		return ErrGroupNotFound
+	}
+
+	if err := r.db.Create(permission).Error; err != nil {
+		if isDuplicateKeyError(err) {
+			return ErrPermissionConflict
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (r *GormRepository) UpdatePermissionType(id string, permissionType PermissionType) (*ResourcePermission, error) {
+	var existing ResourcePermission
+	if err := r.db.First(&existing, "id = ?", id).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, ErrPermissionNotFound
+		}
+		return nil, err
+	}
+
+	if existing.PermissionType == permissionType {
+		return nil, ErrPermissionConflict
+	}
+
+	result := r.db.Model(&ResourcePermission{}).
+		Where("id = ?", id).
+		Update("permission_type", permissionType)
+
+	if result.Error != nil {
+		if isDuplicateKeyError(result.Error) {
+			return nil, ErrPermissionConflict
+		}
+		return nil, result.Error
+	}
+
+	if result.RowsAffected == 0 {
+		return nil, ErrPermissionNotFound
+	}
+
+	var updated ResourcePermission
+	if err := r.db.First(&updated, "id = ?", id).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, ErrPermissionNotFound
+		}
+		return nil, err
+	}
+
+	return &updated, nil
+}
+
+func (r *GormRepository) DeletePermission(id string) error {
+	result := r.db.Delete(&ResourcePermission{}, "id = ?", id)
+	if result.Error != nil {
+		return result.Error
+	}
+
+	if result.RowsAffected == 0 {
+		return ErrPermissionNotFound
+	}
+
+	return nil
+}
+
+func (r *GormRepository) GetPermissionsByGroupID(groupID string) ([]GroupPermissionResult, error) {
+	var groupCount int64
+	if err := r.db.Table("groups").Where("id = ?", groupID).Count(&groupCount).Error; err != nil {
+		return nil, err
+	}
+	if groupCount == 0 {
+		return nil, ErrGroupNotFound
+	}
+
+	var permissions []GroupPermissionResult
+	err := r.db.Table("resource_permissions rp").
+		Select("rp.id, rp.resource_id, r.name AS resource_name, rp.permission_type").
+		Joins("JOIN resources r ON r.id = rp.resource_id").
+		Where("rp.group_id = ?", groupID).
+		Order("r.name ASC").
+		Order("rp.permission_type ASC").
+		Scan(&permissions).Error
+	if err != nil {
+		return nil, err
+	}
+
+	return permissions, nil
+}
+
+func isDuplicateKeyError(err error) bool {
+	if mysqlErr, ok := err.(*mysqlDriver.MySQLError); ok {
+		return mysqlErr.Number == 1062
+	}
+
+	return strings.Contains(strings.ToLower(err.Error()), "duplicate")
+}

--- a/resource-app/backend/internal/permission/services.go
+++ b/resource-app/backend/internal/permission/services.go
@@ -1,0 +1,36 @@
+package permission
+
+import "github.com/google/uuid"
+
+type Service struct {
+	repo Repository
+}
+
+func NewService(repo Repository) *Service {
+	return &Service{repo: repo}
+}
+
+func (s *Service) CreatePermission(permission *ResourcePermission) error {
+	if !IsValidPermissionType(permission.PermissionType) {
+		return ErrInvalidPermissionType
+	}
+
+	permission.ID = uuid.New().String()
+	return s.repo.CreatePermission(permission)
+}
+
+func (s *Service) UpdatePermissionType(id string, permissionType PermissionType) (*ResourcePermission, error) {
+	if !IsValidPermissionType(permissionType) {
+		return nil, ErrInvalidPermissionType
+	}
+
+	return s.repo.UpdatePermissionType(id, permissionType)
+}
+
+func (s *Service) DeletePermission(id string) error {
+	return s.repo.DeletePermission(id)
+}
+
+func (s *Service) GetPermissionsByGroupID(groupID string) ([]GroupPermissionResult, error) {
+	return s.repo.GetPermissionsByGroupID(groupID)
+}

--- a/resource-app/backend/internal/permission/utils.go
+++ b/resource-app/backend/internal/permission/utils.go
@@ -1,0 +1,21 @@
+package permission
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+func mapPermissionErrorToResponse(err error, defaultMsg string) (int, gin.H) {
+	switch {
+	case errors.Is(err, ErrInvalidPermissionType):
+		return http.StatusBadRequest, gin.H{"error": err.Error()}
+	case errors.Is(err, ErrResourceNotFound), errors.Is(err, ErrGroupNotFound), errors.Is(err, ErrPermissionNotFound):
+		return http.StatusNotFound, gin.H{"error": err.Error()}
+	case errors.Is(err, ErrPermissionConflict):
+		return http.StatusConflict, gin.H{"error": err.Error()}
+	default:
+		return http.StatusInternalServerError, gin.H{"error": defaultMsg}
+	}
+}

--- a/resource-app/backend/internal/resource/models.go
+++ b/resource-app/backend/internal/resource/models.go
@@ -17,5 +17,6 @@ type Resource struct {
 	Specs            json.RawMessage `json:"specs" gorm:"type:json"`      // Stored as JSON
 	FormFields       json.RawMessage `json:"formFields" gorm:"type:json"` // Stored as JSON
 	CreatedAt        time.Time       `json:"createdAt" gorm:"autoCreateTime"`
+	UpdatedAt        time.Time       `json:"updatedAt" gorm:"autoUpdateTime"`
 }
 

--- a/resource-app/backend/migrations/003_create_resource_permissions.sql
+++ b/resource-app/backend/migrations/003_create_resource_permissions.sql
@@ -5,9 +5,12 @@ CREATE TABLE IF NOT EXISTS `resource_permissions` (
     `group_id` VARCHAR(36) NOT NULL,
     `permission_type` VARCHAR(20) NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 
     INDEX `idx_resource_permissions_resource` (`resource_id`),
     INDEX `idx_resource_permissions_group` (`group_id`),
+    -- Intentionally includes permission_type to allow multiple permission entries
+    -- (e.g., REQUEST and APPROVE) for the same resource-group pair.
     UNIQUE KEY `uk_resource_group_permission` (`resource_id`, `group_id`, `permission_type`),
 
     CONSTRAINT `fk_resource_permissions_resource`

--- a/resource-app/backend/migrations/003_create_resource_permissions.sql
+++ b/resource-app/backend/migrations/003_create_resource_permissions.sql
@@ -1,0 +1,24 @@
+-- RESOURCE_PERMISSIONS TABLE
+CREATE TABLE IF NOT EXISTS `resource_permissions` (
+    `id` VARCHAR(36) PRIMARY KEY,
+    `resource_id` VARCHAR(36) NOT NULL,
+    `group_id` VARCHAR(36) NOT NULL,
+    `permission_type` VARCHAR(20) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+    INDEX `idx_resource_permissions_resource` (`resource_id`),
+    INDEX `idx_resource_permissions_group` (`group_id`),
+    UNIQUE KEY `uk_resource_group_permission` (`resource_id`, `group_id`, `permission_type`),
+
+    CONSTRAINT `fk_resource_permissions_resource`
+        FOREIGN KEY (`resource_id`)
+        REFERENCES `resources`(`id`)
+        ON DELETE CASCADE
+        ON UPDATE CASCADE,
+
+    CONSTRAINT `fk_resource_permissions_group`
+        FOREIGN KEY (`group_id`)
+        REFERENCES `groups`(`id`)
+        ON DELETE CASCADE
+        ON UPDATE CASCADE
+);

--- a/resource-app/backend/migrations/004_add_updated_at_timestamps.sql
+++ b/resource-app/backend/migrations/004_add_updated_at_timestamps.sql
@@ -1,0 +1,15 @@
+-- Add updated_at timestamps to resource app tables
+
+-- Add updated_at to resources table
+ALTER TABLE resources
+ADD COLUMN updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+
+-- Add updated_at to bookings table
+ALTER TABLE bookings
+ADD COLUMN updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+
+-- Add created_at and updated_at to user_groups table
+ALTER TABLE user_groups
+ADD COLUMN created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+


### PR DESCRIPTION
### Overview  
This PR completes the Permission domain implementation for the Resource bounded context. It adds DDD-style flows for permission endpoints and enforces consistent domain rules (unique group-resource-permission, permission type validation) with repository/service separation.

- POST `/api/resource-permissions`
- PATCH `/api/resource-permissions/:id`
- DELETE `/api/resource-permissions/:id`
- GET `/api/groups/:id/permissions`
#
### What added  
- `cmd/server/main.go`: route registration for permission endpoints  
- `internal/permission/handlers.go`: handlers + input validation + status code mapping  
- `internal/permission/service.go`: permission business rules (create/update/delete/list)  
- `internal/permission/repository.go`: repository methods with DB checks and conflict handling  
- `internal/permission/models.go`: domain model and request/response models  
- `internal/permission/constants.go`: permission type constants and domain errors (`REQUEST`, `APPROVE`, `ErrPermissionConflict`, etc.)  
- `internal/db/db.go`: auto-migrate `permission.ResourcePermission` included
#
### How to test locally  
1. ensure DB is ready (MySQL + `resource_app`)  
2. apply migrations  
3. run tests:  
```bash
go test ./...
```  
4. run server:  
```bash
go run ./cmd/server/main.go
```  
#
### 5. test endpoints:
- `GET /api/groups/:groupId/permissions`
- `POST /api/resource-permissions`
- `PATCH /api/resource-permissions/:id`
- `DELETE /api/resource-permissions/:id`

**Behavior expectations**  
- duplicate group+resource+permission entries return `409 Conflict` ("permission already exists for this group and resource")  
- invalid type returns `400 Bad Request`  
- missing resources/groups/permission IDs return `404 Not Found`  
- successful creations/updates return `201`/`200` with expected payload  
- booking/resource/user behavior is unchanged.

<img width="913" height="772" alt="image" src="https://github.com/user-attachments/assets/b557a677-3bed-4b6d-a6a4-74833ec94341" />
<img width="905" height="757" alt="image" src="https://github.com/user-attachments/assets/3afd7b46-754b-46f6-a93f-7a82dad10d15" />
<img width="908" height="539" alt="image" src="https://github.com/user-attachments/assets/54653d37-0f16-41c3-82c2-eb1045a7f82d" />
<img width="905" height="601" alt="image" src="https://github.com/user-attachments/assets/77e6a2a9-2650-4d3f-8ac2-aa5165b42208" />

closes #75
closes #71  