### PR TITLE
[RESOURCE APP][BACKEND][REFACTOR] Support optional initial user assignment in group creation

### DIFF
--- a/resource-app/backend/internal/group/handlers.go
+++ b/resource-app/backend/internal/group/handlers.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"log"
 	"net/http"
-	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -14,20 +13,12 @@ func HandleCreateGroup(svc *Service) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var payload CreateGroupPayload
 		if err := c.ShouldBindJSON(&payload); err != nil {
-			if strings.Contains(err.Error(), "CreateGroupPayload.UserIDs") {
-				c.JSON(http.StatusBadRequest, gin.H{"error": "Cannot create group. At least one user should be there"})
-				return
-			}
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
 
-		group := Group{
-			Name:        payload.Name,
-			Description: payload.Description,
-		}
-
-		if err := svc.CreateGroup(&group, payload.UserIDs); err != nil {
+		group, err := svc.CreateGroup(&payload)
+		if err != nil {
 			log.Printf("error creating group: %v", err)
 			switch {
 			case errors.Is(err, ErrUserNotFound):

--- a/resource-app/backend/internal/group/models.go
+++ b/resource-app/backend/internal/group/models.go
@@ -21,10 +21,41 @@ type UserGroup struct {
 type CreateGroupPayload struct {
 	Name        string   `json:"name" binding:"required"`
 	Description string   `json:"description"`
-	UserIDs     []string `json:"userIds" binding:"required,min=1,dive,required,uuid"`
+	UserIDs     []string `json:"userIds,omitempty" binding:"omitempty,dive,required,uuid"`
+}
+
+type CreateGroupResult struct {
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	UserIDs     []string  `json:"userIds"`
 }
 
 type UpdateGroupPayload struct {
 	Name        string `json:"name" binding:"required"`
 	Description string `json:"description"`
+}
+
+type AddedUserResult struct {
+	UserID string `json:"user_id"`
+}
+
+type AddUsersToGroupRequest struct {
+	UserIDs []string `json:"user_ids" binding:"required,min=1,dive,required"`
+}
+
+type AddUsersToGroupResult struct {
+	GroupID    string            `json:"group_id"`
+	AddedUsers []AddedUserResult `json:"added_users"`
+}
+
+type RemoveUserFromGroupResult struct {
+	GroupID string `json:"group_id"`
+	UserID  string `json:"user_id"`
+}
+
+type GroupMemberResult struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Email string `json:"email"`
 }

--- a/resource-app/backend/internal/group/repository.go
+++ b/resource-app/backend/internal/group/repository.go
@@ -13,7 +13,7 @@ var ErrUserNotFound = errors.New("one or more users not found")
 var ErrGroupMembershipNotFound = errors.New("group membership not found")
 
 type Repository interface {
-	CreateGroup(group *Group, userIDs []string) error
+	CreateGroup(createGroup *CreateGroupPayload) (*CreateGroupResult, error)
 	GetGroups() ([]Group, error)
 	UpdateGroup(group *Group) error
 	DeleteGroup(id string) error
@@ -43,15 +43,42 @@ func uniqueStringIDs(ids []string) []string {
 	return unique
 }
 
-func (r *GormRepository) CreateGroup(group *Group, userIDs []string) error {
-	return r.db.Transaction(func(tx *gorm.DB) error {
+func (r *GormRepository) CreateGroup(createGroup *CreateGroupPayload) (*CreateGroupResult, error) {
+	group := &Group{
+		ID:          uuid.New().String(),
+		Name:        createGroup.Name,
+		Description: createGroup.Description,
+	}
+
+	addedUserIDs := make([]string, 0)
+
+	err := r.db.Transaction(func(tx *gorm.DB) error {
 		if err := tx.Create(group).Error; err != nil {
 			return err
 		}
 
-		_, err := r.assignUsersToGroupTx(tx, group.ID, userIDs, false)
-		return err
+		result, err := r.assignUsersToGroupTx(tx, group.ID, createGroup.UserIDs, false)
+		if err != nil {
+			return err
+		}
+
+		addedUserIDs = make([]string, 0, len(result.AddedUsers))
+		for _, addedUser := range result.AddedUsers {
+			addedUserIDs = append(addedUserIDs, addedUser.UserID)
+		}
+
+		return nil
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &CreateGroupResult{
+		ID:          group.ID,
+		Name:        group.Name,
+		Description: group.Description,
+		UserIDs:     addedUserIDs,
+	}, nil
 }
 
 func (r *GormRepository) GetGroups() ([]Group, error) {

--- a/resource-app/backend/internal/group/services.go
+++ b/resource-app/backend/internal/group/services.go
@@ -1,31 +1,5 @@
 package group
 
-import "github.com/google/uuid"
-
-type AddedUserResult struct {
-	UserID string `json:"user_id"`
-}
-
-type AddUsersToGroupRequest struct {
-	UserIDs []string `json:"user_ids" binding:"required,min=1,dive,required"`
-}
-
-type AddUsersToGroupResult struct {
-	GroupID    string            `json:"group_id"`
-	AddedUsers []AddedUserResult `json:"added_users"`
-}
-
-type RemoveUserFromGroupResult struct {
-	GroupID string `json:"group_id"`
-	UserID  string `json:"user_id"`
-}
-
-type GroupMemberResult struct {
-	ID    string `json:"id"`
-	Name  string `json:"name"`
-	Email string `json:"email"`
-}
-
 type Service struct {
 	repo Repository
 }
@@ -34,9 +8,8 @@ func NewService(repo Repository) *Service {
 	return &Service{repo: repo}
 }
 
-func (s *Service) CreateGroup(group *Group, userIDs []string) error {
-	group.ID = uuid.New().String()
-	return s.repo.CreateGroup(group, userIDs)
+func (s *Service) CreateGroup(createGroup *CreateGroupPayload) (*CreateGroupResult, error) {
+	return s.repo.CreateGroup(createGroup)
 }
 
 func (s *Service) GetGroups() ([]Group, error) {


### PR DESCRIPTION
## Summary
- Refactored group creation to support optional user assignment at creation time.
- Allowed groups to be created with or without initial members.
- Preserved transactional user assignment when `userIds` are provided.
- Kept existing add/remove/list group membership endpoints intact.
- Reused shared membership-assignment logic across create-group and add-users flows.

## Why
- Updated business requirement now allows groups to be created first and members to be assigned later if needed.
- Previous implementation enforced at first neet to create a group, and then assign users to groups.

## What Changed
- `POST /api/groups` now accepts `userIds` as an optional field in the request payload.
- Group creation flow now supports:
  1. creating a group without users
  2. creating a group with initial users
- Group service and repository create flow still assigns users within a transaction when `userIds` are provided.
- Shared membership logic remains centralized and reused by:
  1. group creation flow
  2. `POST /api/groups/:id/users` flow
- Existing endpoints retained:
  1. `POST /api/groups/:id/users`
  2. `DELETE /api/groups/:id/users/:userId`
  3. `GET /api/groups/:id/users`

## Behavior Notes
- If `userIds` are not provided or are empty during group creation, the group is still created successfully.
- If `userIds` are provided during group creation:
  - all provided users must exist
  - duplicate user IDs in the same request are rejected
  - membership assignment happens as part of the same transactional flow
- For `POST /api/groups/:id/users`, users already in the group are ignored; other valid users are added.

## Testing
- Ran backend test/build validation with `go test ./...`
- Result: pass

## Related
- Updates the previously implemented member-required group creation flow


_Group Creation with Initial Users_
<img width="920" height="767" alt="image" src="https://github.com/user-attachments/assets/0f4bf300-49d2-422b-a6ac-3514f4be927a" />
<img width="895" height="344" alt="image" src="https://github.com/user-attachments/assets/99ac264b-10ac-4826-9249-cf61e4b4c40b" />


_Group Creation without Initial Users_
<img width="923" height="734" alt="image" src="https://github.com/user-attachments/assets/e0178cdc-fef8-4d58-9f68-32887187f8b7" />
<img width="907" height="326" alt="image" src="https://github.com/user-attachments/assets/ca41cf85-ca87-465d-8e64-bed6d1c312d6" />

<img width="926" height="761" alt="image" src="https://github.com/user-attachments/assets/d1a1a47f-7b27-459b-958d-0ff40bf6d519" />
<img width="910" height="326" alt="image" src="https://github.com/user-attachments/assets/334e0047-3bbb-40d3-b8c5-b2fb1b538742" />

- Closes #96 
- Closes #100 