### PR TITLE
[RESOURCE APP][BACKEND][IMPROVEMENT] Align model naming with API and GORM conventions

### DIFF
--- a/resource-app/backend/internal/group/models.go
+++ b/resource-app/backend/internal/group/models.go
@@ -12,8 +12,8 @@ type Group struct {
 
 type UserGroup struct {
 	ID        string    `json:"id" gorm:"type:varchar(36);primaryKey"`
-	UserID    string    `json:"userId" gorm:"column:user_id;type:varchar(36);not null;index"`
-	GroupID   string    `json:"groupId" gorm:"column:group_id;type:varchar(36);not null;index"`
+	UserID    string    `json:"userId" gorm:"type:varchar(36);not null;index"`
+	GroupID   string    `json:"groupId" gorm:"type:varchar(36);not null;index"`
 	CreatedAt time.Time `json:"createdAt" gorm:"autoCreateTime"`
 	UpdatedAt time.Time `json:"updatedAt" gorm:"autoUpdateTime"`
 }
@@ -37,21 +37,21 @@ type UpdateGroupPayload struct {
 }
 
 type AddedUserResult struct {
-	UserID string `json:"user_id"`
+	UserID string `json:"userId"`
 }
 
 type AddUsersToGroupRequest struct {
-	UserIDs []string `json:"user_ids" binding:"required,min=1,dive,required"`
+	UserIDs []string `json:"userIds" binding:"required,min=1,dive,required"`
 }
 
 type AddUsersToGroupResult struct {
-	GroupID    string            `json:"group_id"`
-	AddedUsers []AddedUserResult `json:"added_users"`
+	GroupID    string            `json:"groupId"`
+	AddedUsers []AddedUserResult `json:"addedUsers"`
 }
 
 type RemoveUserFromGroupResult struct {
-	GroupID string `json:"group_id"`
-	UserID  string `json:"user_id"`
+	GroupID string `json:"groupId"`
+	UserID  string `json:"userId"`
 }
 
 type GroupMemberResult struct {

--- a/resource-app/backend/internal/permission/models.go
+++ b/resource-app/backend/internal/permission/models.go
@@ -4,9 +4,9 @@ import "time"
 
 type ResourcePermission struct {
 	ID             string         `json:"id" gorm:"primaryKey;type:varchar(36)"`
-	ResourceID     string         `json:"resourceId" gorm:"column:resource_id;type:varchar(36);not null;index"`
-	GroupID        string         `json:"groupId" gorm:"column:group_id;type:varchar(36);not null;index"`
-	PermissionType PermissionType `json:"permissionType" gorm:"column:permission_type;type:varchar(20);not null"`
+	ResourceID     string         `json:"resourceId" gorm:"type:varchar(36);not null;index"`
+	GroupID        string         `json:"groupId" gorm:"type:varchar(36);not null;index"`
+	PermissionType PermissionType `json:"permissionType" gorm:"type:varchar(20);not null"`
 	CreatedAt      time.Time      `json:"createdAt" gorm:"autoCreateTime"`
 	UpdatedAt      time.Time      `json:"updatedAt" gorm:"autoUpdateTime"`
 }
@@ -27,7 +27,7 @@ type UpdatePermissionTypeRequest struct {
 
 type GroupPermissionResult struct {
 	ID             string         `json:"id"`
-	ResourceID     string         `json:"resourceId" gorm:"column:resource_id"`
-	ResourceName   string         `json:"resourceName" gorm:"column:resource_name"`
-	PermissionType PermissionType `json:"permissionType" gorm:"column:permission_type"`
+	ResourceID     string         `json:"resourceId"`
+	ResourceName   string         `json:"resourceName"`
+	PermissionType PermissionType `json:"permissionType"`
 }


### PR DESCRIPTION
## Description

This PR updates the backend model definitions to match the current codebase conventions:

- API JSON fields use `camelCase`
- GORM model fields rely on default mapping instead of explicit column tags where they are unnecessary
- Database table naming stays unchanged where an explicit table name is already required

This keeps the API contract consistent and reduces model-level configuration noise.

## Changes

### Group Model
- Changed group membership response/request JSON fields from `snake_case` to `camelCase`
- Removed explicit `gorm:"column:..."` tags from `UserGroup` fields

### Permission Model
- Removed explicit `gorm:"column:..."` tags from permission model fields
- Kept JSON fields in `camelCase`
- Kept the explicit table name mapping for `resource_permissions`

## Impact

- API payloads and responses remain consistent with frontend-friendly naming
- Model definitions are simpler and easier to maintain
- No business logic changes
- No endpoint behavior changes intended