### PR TITLE
[RESOURCE APP][BACKEND][FEAT] Add OpenAPI YAML Files

### DIFF
--- a/resource-app/backend/api/booking.yaml
+++ b/resource-app/backend/api/booking.yaml
@@ -1,0 +1,466 @@
+openapi: 3.0.0
+info:
+  title: Booking Domain API
+  description: API endpoints for managing resource bookings and utilization stats in the resource-app
+  version: 1.0.0
+
+servers:
+  - url: http://localhost:8082/api
+    description: API server (local)
+  - url: /api
+    description: API server (relative)
+
+paths:
+  /bookings:
+    get:
+      summary: Get all bookings
+      description: Retrieve a list of all bookings
+      operationId: getBookings
+      tags:
+        - Bookings
+      security:
+        - BearerAuth: []
+      responses:
+        "200":
+          description: Successfully retrieved bookings
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Booking"
+        "500":
+          description: Failed to fetch bookings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+    post:
+      summary: Create a new booking
+      description: Create a new booking for a resource
+      operationId: createBooking
+      tags:
+        - Bookings
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateBookingRequest"
+      responses:
+        "201":
+          description: Booking created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: "#/components/schemas/Booking"
+        "400":
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: User not authenticated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: User does not have permission to book this resource
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Resource is already booked for the requested time slot
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Failed to create booking
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /bookings/{id}/process:
+    patch:
+      summary: Process/update booking status
+      description: Confirm, reject, or update the status of a booking
+      operationId: processBooking
+      tags:
+        - Bookings
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Booking ID
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProcessBookingRequest"
+      responses:
+        "200":
+          description: Booking status updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: "#/components/schemas/Booking"
+        "400":
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Booking not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Failed to update booking status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /bookings/{id}/reschedule:
+    patch:
+      summary: Reschedule a booking
+      description: Move a booking to a different time slot
+      operationId: rescheduleBooking
+      tags:
+        - Bookings
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Booking ID
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RescheduleBookingRequest"
+      responses:
+        "200":
+          description: Booking rescheduled successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: "#/components/schemas/Booking"
+        "400":
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Booking not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: New time slot is already booked
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Failed to reschedule booking
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /bookings/{id}:
+    delete:
+      summary: Cancel a booking
+      description: Cancel/delete a booking
+      operationId: cancelBooking
+      tags:
+        - Bookings
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Booking ID
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Booking cancelled successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: boolean
+        "404":
+          description: Booking not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Failed to cancel booking
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /stats:
+    get:
+      summary: Get resource utilization statistics
+      description: Get resource usage statistics and utilization rates
+      operationId: getStats
+      tags:
+        - Statistics
+      security:
+        - BearerAuth: []
+      responses:
+        "200":
+          description: Successfully retrieved utilization statistics
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ResourceUsageStats"
+        "500":
+          description: Failed to calculate stats
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+components:
+  schemas:
+    Booking:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique booking identifier
+        resourceId:
+          type: string
+          format: uuid
+          description: ID of the booked resource
+        userId:
+          type: string
+          format: uuid
+          description: ID of the user who made the booking
+        start:
+          type: string
+          format: date-time
+          description: Start time of the booking
+        end:
+          type: string
+          format: date-time
+          description: End time of the booking
+        status:
+          type: string
+          enum:
+            [
+              pending,
+              confirmed,
+              rejected,
+              cancelled,
+              completed,
+              checked_in,
+              proposed,
+            ]
+          description: Current status of the booking
+        rejectionReason:
+          type: string
+          nullable: true
+          description: Reason for rejection (if status is rejected)
+        details:
+          type: object
+          nullable: true
+          description: Additional booking details in JSON format
+        createdAt:
+          type: string
+          format: date-time
+          description: Timestamp when booking was created
+        updatedAt:
+          type: string
+          format: date-time
+          description: Timestamp when booking was last updated
+      required:
+        - id
+        - resourceId
+        - userId
+        - start
+        - end
+        - status
+
+    ResourceUsageStats:
+      type: object
+      properties:
+        resourceId:
+          type: string
+          format: uuid
+          description: ID of the resource
+        resourceName:
+          type: string
+          description: Name of the resource
+        resourceType:
+          type: string
+          description: Type of the resource
+        bookingCount:
+          type: integer
+          description: Total number of bookings
+        totalHours:
+          type: integer
+          description: Total hours booked
+        utilizationRate:
+          type: integer
+          description: Utilization rate as a percentage
+
+    CreateBookingRequest:
+      type: object
+      properties:
+        resourceId:
+          type: string
+          format: uuid
+          description: ID of the resource to book
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        start:
+          type: string
+          format: date-time
+          description: Start time of the booking
+          example: "2024-04-15T09:00:00Z"
+        end:
+          type: string
+          format: date-time
+          description: End time of the booking
+          example: "2024-04-15T11:00:00Z"
+        details:
+          type: object
+          nullable: true
+          description: Additional booking details in JSON format
+          example: { "purpose": "Team meeting", "attendees": 5 }
+      required:
+        - resourceId
+        - start
+        - end
+
+    ProcessBookingRequest:
+      type: object
+      properties:
+        status:
+          type: string
+          enum:
+            [
+              pending,
+              confirmed,
+              rejected,
+              cancelled,
+              completed,
+              checked_in,
+              proposed,
+            ]
+          description: New status for the booking
+          example: "confirmed"
+        rejectionReason:
+          type: string
+          description: Reason for rejection (typically provided when status is rejected)
+          example: "Resource not available"
+      required:
+        - status
+
+    RescheduleBookingRequest:
+      type: object
+      properties:
+        start:
+          type: string
+          format: date-time
+          description: New start time for the booking
+          example: "2024-04-16T09:00:00Z"
+        end:
+          type: string
+          format: date-time
+          description: New end time for the booking
+          example: "2024-04-16T11:00:00Z"
+      required:
+        - start
+        - end
+
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+          description: Error message
+      required:
+        - error
+
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT

--- a/resource-app/backend/api/group.yaml
+++ b/resource-app/backend/api/group.yaml
@@ -1,0 +1,514 @@
+openapi: 3.0.0
+info:
+  title: Group Domain API
+  description: API endpoints for managing groups and group memberships in the resource-app
+  version: 1.0.0
+
+servers:
+  - url: http://localhost:8082/api
+    description: API server (local)
+  - url: /api
+    description: API server (relative)
+
+paths:
+  /groups:
+    post:
+      summary: Create a new group
+      description: Create a new group with optional initial members. Requires Admin privileges.  
+      operationId: createGroup
+      tags:
+        - Groups
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateGroupRequest"
+      responses:
+        "201":
+          description: Group created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: "#/components/schemas/CreateGroupResult"
+        "400":
+          description: Invalid input or missing required fields
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: User not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Failed to create group
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+    get:
+      summary: Get all groups
+      description: Retrieve a list of all groups. Requires Admin privileges.  
+      operationId: getGroups
+      tags:
+        - Groups
+      security:
+        - BearerAuth: []
+      responses:
+        "200":
+          description: Successfully retrieved groups
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Group"
+        "500":
+          description: Failed to fetch groups
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /groups/{id}:
+    patch:
+      summary: Update a group
+      description: Update group name and description
+      operationId: updateGroup
+      tags:
+        - Groups
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Group ID
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateGroupRequest"
+      responses:
+        "200":
+          description: Group updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: "#/components/schemas/Group"
+        "400":
+          description: Invalid input or invalid group ID format
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Group not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Failed to update group
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+    delete:
+      summary: Delete a group
+      description: Delete a group by ID
+      operationId: deleteGroup
+      tags:
+        - Groups
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Group ID
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Group deleted successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: boolean
+        "400":
+          description: Invalid group ID format
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Group not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Failed to delete group
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /groups/{id}/users:
+    get:
+      summary: Get group members
+      description: Get all members of a specific group
+      operationId: getGroupMembers
+      tags:
+        - Group Membership
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Group ID
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Successfully retrieved group members
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                          description: User ID
+                        name:
+                          type: string
+                          description: User name
+                        email:
+                          type: string
+                          format: email
+                          description: User email
+        "400":
+          description: Invalid group ID format
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Group not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Failed to fetch group members
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+    post:
+      summary: Add users to a group
+      description: Add one or more users to a specific group
+      operationId: addUsersToGroup
+      tags:
+        - Group Membership
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Group ID
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AddUsersToGroupRequest"
+      responses:
+        "201":
+          description: Users added to group successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: "#/components/schemas/AddUsersToGroupResult"
+        "400":
+          description: Invalid input or invalid IDs format
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Group or user not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Failed to add users to group
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /groups/{id}/users/{userId}:
+    delete:
+      summary: Remove user from group
+      description: Remove a specific user from a group
+      operationId: removeUserFromGroup
+      tags:
+        - Group Membership
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Group ID
+          schema:
+            type: string
+            format: uuid
+        - name: userId
+          in: path
+          required: true
+          description: User ID
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: User removed from group successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      groupId:
+                        type: string
+                        format: uuid
+                      userId:
+                        type: string
+                        format: uuid
+        "400":
+          description: Invalid ID format
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Group or group membership not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Failed to remove user from group
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+components:
+  schemas:
+    Group:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique group identifier
+        name:
+          type: string
+          description: Name of the group
+        description:
+          type: string
+          description: Description of the group
+        createdAt:
+          type: string
+          format: date-time
+          description: Timestamp when group was created
+        updatedAt:
+          type: string
+          format: date-time
+          description: Timestamp when group was last updated
+      required:
+        - id
+        - name
+
+    CreateGroupRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name of the group
+          example: "Engineering Team"
+        description:
+          type: string
+          description: Description of the group
+          example: "Engineering team members"
+        userIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: List of user IDs to add to the group (optional)
+          example:
+            [
+              "550e8400-e29b-41d4-a716-446655440000",
+              "550e8400-e29b-41d4-a716-446655440001",
+            ]
+      required:
+        - name
+
+    CreateGroupResult:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique group identifier
+        name:
+          type: string
+          description: Name of the group
+        description:
+          type: string
+          description: Description of the group
+        createdAt:
+          type: string
+          format: date-time
+          description: Timestamp when group was created
+        updatedAt:
+          type: string
+          format: date-time
+          description: Timestamp when group was last updated
+        userIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: List of user IDs in the group
+
+    UpdateGroupRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name of the group
+          example: "Engineering Team"
+        description:
+          type: string
+          description: Description of the group
+          example: "Engineering team members"
+      required:
+        - name
+
+    AddUsersToGroupRequest:
+      type: object
+      properties:
+        userIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: List of user IDs to add to the group
+          example:
+            [
+              "550e8400-e29b-41d4-a716-446655440000",
+              "550e8400-e29b-41d4-a716-446655440001",
+            ]
+      required:
+        - userIds
+
+    AddUsersToGroupResult:
+      type: object
+      properties:
+        groupId:
+          type: string
+          format: uuid
+          description: Group ID
+        addedUsers:
+          type: array
+          items:
+            type: object
+            properties:
+              userId:
+                type: string
+                format: uuid
+
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+          description: Error message
+      required:
+        - error
+
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT

--- a/resource-app/backend/api/permission.yaml
+++ b/resource-app/backend/api/permission.yaml
@@ -1,0 +1,392 @@
+openapi: 3.0.0
+info:
+  title: Permission Domain API
+  description: API endpoints for managing resource permissions and group access control in the resource-app. All endpoints in this domain require Admin privileges.  
+  version: 1.0.0
+
+servers:
+  - url: http://localhost:8082/api
+    description: API server (local)
+  - url: /api
+    description: API server (relative)
+
+paths:
+  /resource-permissions:
+    post:
+      summary: Create a resource permission
+      description: Grant a group permission to access a specific resource
+      operationId: createPermission
+      tags:
+        - Permissions
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreatePermissionRequest"
+      responses:
+        "201":
+          description: Permission created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: "#/components/schemas/ResourcePermission"
+        "400":
+          description: Invalid input, invalid IDs format, or invalid permission type
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Resource or group not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Permission already exists for the same group and resource
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Failed to create permission
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /resource-permissions/{id}:
+    patch:
+      summary: Update permission type
+      description: Update the permission type for an existing resource permission
+      operationId: updatePermissionType
+      tags:
+        - Permissions
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Permission ID
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdatePermissionTypeRequest"
+      responses:
+        "200":
+          description: Permission type updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: "#/components/schemas/ResourcePermission"
+        "400":
+          description: Invalid input, invalid permission ID format, or invalid permission type
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Permission not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Permission conflict
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Failed to update permission
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+    delete:
+      summary: Delete a permission
+      description: Remove a resource permission for a group
+      operationId: deletePermission
+      tags:
+        - Permissions
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Permission ID
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Permission deleted successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: boolean
+        "400":
+          description: Invalid permission ID format
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Permission not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Failed to delete permission
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /groups/{id}/permissions:
+    get:
+      summary: Get group permissions
+      description: Get all resource permissions for a specific group
+      operationId: getGroupPermissions
+      tags:
+        - Permissions
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Group ID
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Successfully retrieved group permissions
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/GroupPermissionResult"
+        "400":
+          description: Invalid group ID format
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Group not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Failed to fetch group permissions
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /resources/{id}/permissions:
+    get:
+      summary: Get resource permissions
+      description: Get all group permissions for a specific resource
+      operationId: getResourcePermissions
+      tags:
+        - Permissions
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Resource ID
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Successfully retrieved resource permissions
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ResourcePermissionResult"
+        "404":
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Failed to fetch resource permissions
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+components:
+  schemas:
+    ResourcePermission:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique permission identifier
+        resourceId:
+          type: string
+          format: uuid
+          description: ID of the resource
+        groupId:
+          type: string
+          format: uuid
+          description: ID of the group
+        permissionType:
+          type: string
+          enum: [REQUEST, APPROVE]
+          description: Type of permission granted to the group
+        createdAt:
+          type: string
+          format: date-time
+          description: Timestamp when permission was created
+        updatedAt:
+          type: string
+          format: date-time
+          description: Timestamp when permission was last updated
+      required:
+        - id
+        - resourceId
+        - groupId
+        - permissionType
+
+    GroupPermissionResult:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique permission identifier
+        resourceId:
+          type: string
+          format: uuid
+          description: ID of the resource
+        resourceName:
+          type: string
+          description: Name of the resource
+        permissionType:
+          type: string
+          enum: [REQUEST, APPROVE]
+          description: Type of permission granted to the group
+
+    ResourcePermissionResult:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique permission identifier
+        groupId:
+          type: string
+          format: uuid
+          description: ID of the group
+        groupName:
+          type: string
+          description: Name of the group
+        permissionType:
+          type: string
+          enum: [REQUEST, APPROVE]
+          description: Type of permission granted to the group
+
+    CreatePermissionRequest:
+      type: object
+      properties:
+        resourceId:
+          type: string
+          format: uuid
+          description: ID of the resource
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        groupId:
+          type: string
+          format: uuid
+          description: ID of the group
+          example: "550e8400-e29b-41d4-a716-446655440001"
+        permissionType:
+          type: string
+          enum: [REQUEST, APPROVE]
+          description: Type of permission to grant
+          example: "REQUEST"
+      required:
+        - resourceId
+        - groupId
+        - permissionType
+
+    UpdatePermissionTypeRequest:
+      type: object
+      properties:
+        permissionType:
+          type: string
+          enum: [REQUEST, APPROVE]
+          description: New permission type
+          example: "APPROVE"
+      required:
+        - permissionType
+
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+          description: Error message
+      required:
+        - error
+
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT

--- a/resource-app/backend/api/resource.yaml
+++ b/resource-app/backend/api/resource.yaml
@@ -1,0 +1,281 @@
+openapi: 3.0.0
+info:
+  title: Resource Domain API
+  description: API endpoints for managing resources in the resource-app
+  version: 1.0.0
+
+servers:
+  - url: http://localhost:8082/api
+    description: API server (local)
+  - url: /api
+    description: API server (relative)
+
+paths:
+  /resources:
+    get:
+      summary: Get all resources
+      description: Retrieve a list of all available resources
+      operationId: getResources
+      tags:
+        - Resources
+      security:
+        - BearerAuth: []
+      responses:
+        "200":
+          description: Successfully retrieved resources
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Resource"
+        "500":
+          description: Failed to fetch resources
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+    post:
+      summary: Create a new resource
+      description: Create a new resource with the provided details. Requires Admin privileges.  
+      operationId: createResource
+      tags:
+        - Resources
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateResourceRequest"
+      responses:
+        "201":
+          description: Resource created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: "#/components/schemas/Resource"
+        "400":
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Failed to create resource
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /resources/{id}:
+    put:
+      summary: Update a resource
+      description: Update an existing resource by ID. Requires Admin privileges.  
+      operationId: updateResource
+      tags:
+        - Resources
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Resource ID
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateResourceRequest"
+      responses:
+        "200":
+          description: Resource updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: "#/components/schemas/Resource"
+        "400":
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Failed to update resource
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+    delete:
+      summary: Delete a resource
+      description: Delete a resource by ID. Requires Admin privileges.  
+      operationId: deleteResource
+      tags:
+        - Resources
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Resource ID
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Resource deleted successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: boolean
+        "500":
+          description: Failed to delete resource
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+components:
+  schemas:
+    Resource:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique resource identifier
+        name:
+          type: string
+          description: Name of the resource
+        type:
+          type: string
+          description: Type/category of the resource
+        description:
+          type: string
+          description: Description of the resource
+        isActive:
+          type: boolean
+          default: true
+          description: Whether the resource is active
+        minLeadTimeHours:
+          type: integer
+          default: 0
+          description: Minimum lead time required in hours
+        icon:
+          type: string
+          description: Icon identifier for the resource
+        color:
+          type: string
+          description: Color code for the resource
+        specs:
+          type: object
+          nullable: true
+          description: JSON specifications of the resource
+        formFields:
+          type: object
+          nullable: true
+          description: JSON form fields for booking the resource
+        createdAt:
+          type: string
+          format: date-time
+          description: Timestamp when resource was created
+        updatedAt:
+          type: string
+          format: date-time
+          description: Timestamp when resource was last updated
+      required:
+        - id
+        - name
+        - type
+
+    CreateResourceRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name of the resource
+          example: "Conference Room A"
+        type:
+          type: string
+          description: Type/category of the resource
+          example: "room"
+        description:
+          type: string
+          description: Description of the resource
+          example: "Large conference room with AV equipment"
+        isActive:
+          type: boolean
+          default: true
+          description: Whether the resource is active
+        minLeadTimeHours:
+          type: integer
+          default: 0
+          description: Minimum lead time required in hours
+          example: 2
+        icon:
+          type: string
+          description: Icon identifier for the resource
+          example: "conference-room"
+        color:
+          type: string
+          description: Color code for the resource
+          example: "#FF5733"
+        specs:
+          type: object
+          nullable: true
+          description: JSON specifications of the resource
+          example: { "capacity": 20, "hasVideo": true }
+        formFields:
+          type: object
+          nullable: true
+          description: JSON form fields for booking the resource
+      required:
+        - name
+        - type
+
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+          description: Error message
+      required:
+        - error
+
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT


### PR DESCRIPTION
## Summary 

- Added top-level OpenAPI folder:
  - api
- Added domain YAML files:
  - `api/resource.yaml`
  - `api/group.yaml`
  - `api/permission.yaml`
  - `api/booking.yaml`
- Each file documents:
  - routes implemented in backend
  - request bodies
  - path params
  - response schemas + HTTP status codes
  - example bodies
- Default server port set to `8082` (via `config.DefaultPort` + `PORT` env override)
- Backend route base path: `/api`


## How to test

1. Start backend:
   - `cd resource-app/backend`
   - `go run cmd/server/main.go`
2. Check health:
   - `curl http://localhost:8082/health`
3. Check API endpoints:
   - `curl http://localhost:8082/api/resources`
   - `curl http://localhost:8082/api/groups`
   - `curl http://localhost:8082/api/bookings`
   - `curl http://localhost:8082/api/stats`
4. Validate OpenAPI docs:
   - Open `https://editor.swagger.io/`
   - Import YAML (file -> open file) for each:
     - resource.yaml
     - `.../group.yaml`
     - `.../permission.yaml`
     - `.../booking.yaml`

Result should show valid Swagger UI with all operations and schema details.

<img width="942" height="603" alt="image" src="https://github.com/user-attachments/assets/f02f85d5-d2c4-4e72-bbc9-d2d2ecd6193b" />
<img width="941" height="787" alt="image" src="https://github.com/user-attachments/assets/a55f977e-bec8-4243-8b0c-a555390474f3" />
<img width="943" height="597" alt="image" src="https://github.com/user-attachments/assets/4e831207-45a2-46cd-8b77-e4fde909372d" />
<img width="945" height="777" alt="image" src="https://github.com/user-attachments/assets/febe2868-6870-4b42-8f24-2aca05c72c40" />

Closes #107 