### PR TITLE
[RESORCE APP][BACKEND] Include `createdAt` and `updatedAt` in `CreateGroup` Response

### DIFF
--- a/resource-app/backend/internal/group/models.go
+++ b/resource-app/backend/internal/group/models.go
@@ -28,6 +28,8 @@ type CreateGroupResult struct {
 	ID          string    `json:"id"`
 	Name        string    `json:"name"`
 	Description string    `json:"description"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
 	UserIDs     []string  `json:"userIds"`
 }
 

--- a/resource-app/backend/internal/group/repository.go
+++ b/resource-app/backend/internal/group/repository.go
@@ -77,6 +77,8 @@ func (r *GormRepository) CreateGroup(createGroup *CreateGroupPayload) (*CreateGr
 		ID:          group.ID,
 		Name:        group.Name,
 		Description: group.Description,
+		CreatedAt:   group.CreatedAt,
+		UpdatedAt:   group.UpdatedAt,
 		UserIDs:     addedUserIDs,
 	}, nil
 }


### PR DESCRIPTION
### Overview
This PR updates the `POST /api/groups` endpoint to include the database-generated `createdAt` and `updatedAt` timestamps in its response. Previously, these fields were missing, forcing the frontend to perform a manual refresh or a subsequent `GET` request to display the creation date.

### Changes
- **Models**: Updated `CreateGroupResult` in models.go to include `CreatedAt` and `UpdatedAt` time fields.
- **Repository**: Modified `CreateGroup` in repository.go to:
    - Re-fetch the newly created group record within the transaction using `tx.First`.
    - Populate the `CreateGroupResult` with the re-fetched timestamps.
- **API Documentation**: Added OpenAPI specifications for the Group Domain API and other related services to reflect the current schema.

### Impact
- The frontend can now immediately display the "Created At" timestamp upon successful group creation.
- Improved consistency between the `POST` response and the `GET` list output.


<img width="936" height="663" alt="image" src="https://github.com/user-attachments/assets/5ace3caa-99f0-45c8-a85e-16d7c0955dbb" />
<img width="932" height="321" alt="image" src="https://github.com/user-attachments/assets/162937cc-09bc-4f7f-b1a9-aa55edda96f0" />

closes #105 

