### PR TITLE
[RESOURCE APP][BACKEND]Standardize Successful Delete Operations to 204 No Content

### DIFF
--- a/resource-app/backend/api/group.yaml
+++ b/resource-app/backend/api/group.yaml
@@ -14,7 +14,7 @@ paths:
   /groups:
     post:
       summary: Create a new group
-      description: Create a new group with optional initial members. Requires Admin privileges.  
+      description: Create a new group with optional initial members. Requires Admin privileges.
       operationId: createGroup
       tags:
         - Groups
@@ -60,7 +60,7 @@ paths:
 
     get:
       summary: Get all groups
-      description: Retrieve a list of all groups. Requires Admin privileges.  
+      description: Retrieve a list of all groups. Requires Admin privileges.
       operationId: getGroups
       tags:
         - Groups
@@ -160,18 +160,8 @@ paths:
             type: string
             format: uuid
       responses:
-        "200":
+        "204":
           description: Group deleted successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  success:
-                    type: boolean
-                    example: true
-                  data:
-                    type: boolean
         "400":
           description: Invalid group ID format
           content:
@@ -333,25 +323,8 @@ paths:
             type: string
             format: uuid
       responses:
-        "200":
+        "204":
           description: User removed from group successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  success:
-                    type: boolean
-                    example: true
-                  data:
-                    type: object
-                    properties:
-                      groupId:
-                        type: string
-                        format: uuid
-                      userId:
-                        type: string
-                        format: uuid
         "400":
           description: Invalid ID format
           content:

--- a/resource-app/backend/api/permission.yaml
+++ b/resource-app/backend/api/permission.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Permission Domain API
-  description: API endpoints for managing resource permissions and group access control in the resource-app. All endpoints in this domain require Admin privileges.  
+  description: API endpoints for managing resource permissions and group access control in the resource-app. All endpoints in this domain require Admin privileges.
   version: 1.0.0
 
 servers:
@@ -142,18 +142,8 @@ paths:
             type: string
             format: uuid
       responses:
-        "200":
+        "204":
           description: Permission deleted successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  success:
-                    type: boolean
-                    example: true
-                  data:
-                    type: boolean
         "400":
           description: Invalid permission ID format
           content:

--- a/resource-app/backend/api/resource.yaml
+++ b/resource-app/backend/api/resource.yaml
@@ -44,7 +44,7 @@ paths:
 
     post:
       summary: Create a new resource
-      description: Create a new resource with the provided details. Requires Admin privileges.  
+      description: Create a new resource with the provided details. Requires Admin privileges.
       operationId: createResource
       tags:
         - Resources
@@ -85,7 +85,7 @@ paths:
   /resources/{id}:
     put:
       summary: Update a resource
-      description: Update an existing resource by ID. Requires Admin privileges.  
+      description: Update an existing resource by ID. Requires Admin privileges.
       operationId: updateResource
       tags:
         - Resources
@@ -133,7 +133,7 @@ paths:
 
     delete:
       summary: Delete a resource
-      description: Delete a resource by ID. Requires Admin privileges.  
+      description: Delete a resource by ID. Requires Admin privileges.
       operationId: deleteResource
       tags:
         - Resources
@@ -148,18 +148,8 @@ paths:
             type: string
             format: uuid
       responses:
-        "200":
+        "204":
           description: Resource deleted successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  success:
-                    type: boolean
-                    example: true
-                  data:
-                    type: boolean
         "500":
           description: Failed to delete resource
           content:

--- a/resource-app/backend/internal/group/handlers.go
+++ b/resource-app/backend/internal/group/handlers.go
@@ -94,7 +94,7 @@ func HandleDeleteGroup(svc *Service) gin.HandlerFunc {
 			return
 		}
 
-		c.JSON(http.StatusOK, gin.H{"success": true, "data": true})
+		c.Status(http.StatusNoContent)
 	}
 }
 
@@ -148,7 +148,7 @@ func HandleRemoveUserFromGroup(svc *Service) gin.HandlerFunc {
 			return
 		}
 
-		result, err := svc.RemoveUserFromGroup(groupID, userID)
+		_, err := svc.RemoveUserFromGroup(groupID, userID)
 		if err != nil {
 			switch {
 			case errors.Is(err, ErrGroupNotFound), errors.Is(err, ErrGroupMembershipNotFound):
@@ -159,7 +159,7 @@ func HandleRemoveUserFromGroup(svc *Service) gin.HandlerFunc {
 			return
 		}
 
-		c.JSON(http.StatusOK, gin.H{"success": true, "data": result})
+		c.Status(http.StatusNoContent)
 	}
 }
 

--- a/resource-app/backend/internal/permission/handlers.go
+++ b/resource-app/backend/internal/permission/handlers.go
@@ -100,7 +100,7 @@ func HandleDeletePermission(svc *Service) gin.HandlerFunc {
 			return
 		}
 
-		c.JSON(http.StatusOK, gin.H{"success": true, "data": true})
+		c.Status(http.StatusNoContent)
 	}
 }
 

--- a/resource-app/backend/internal/resource/handlers.go
+++ b/resource-app/backend/internal/resource/handlers.go
@@ -75,6 +75,6 @@ func HandleDeleteResource(svc *Service) gin.HandlerFunc {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete resource"})
 			return
 		}
-		c.JSON(http.StatusOK, gin.H{"success": true, "data": true})
+		c.Status(http.StatusNoContent)
 	}
 }


### PR DESCRIPTION
#### Description
This PR standardizes the API behavior for successful delete operations across all resource-app backend domains. Previously, successful deletions returned a `200 OK` status with a JSON body. To align with RESTful best practices, these endpoints now return `204 No Content` with an empty response body.

#### Changes
Updated the following handlers to return `http.StatusNoContent` (`204`) on success:
-  **Group Domain**: `HandleDeleteGroup` and `HandleRemoveUserFromGroup`
-  **Resource Domain**: `HandleDeleteResource`
-  **Permission Domain**: `HandleDeletePermission`
-  **Booking Domain**: `HandleCancelBooking`

Updated the corresponding OpenAPI specifications (`.yaml`) to reflect the change from `200` to `204` and cleaned up response body schemas for:
-  booking.yaml
-  group.yaml
-  permission.yaml
-  resource.yaml

#### Impact
- **Status Code**: Changed from `200` to `204` for successful deletions.
- **Response Body**: No body is returned for successful deletions.
- **Stability**: Core delete logic, validations, and error handling (400, 404, 500) remain unchanged.

#### Verification
- [x] Verified code changes across all relevant handlers.go files.
- [x] Ensured OpenAPI documentation matches the updated implementation.
- [x] Confirmed no linting or compilation errors in updated backend files.

_Resources_
<img width="915" height="803" alt="image" src="https://github.com/user-attachments/assets/ab1c83d5-24de-40ba-b3b1-cc03eb7211ed" />

_Groups_
<img width="915" height="801" alt="image" src="https://github.com/user-attachments/assets/92d1b8b1-a0f7-4ff4-88b1-800b9947b0a8" />
<img width="917" height="776" alt="image" src="https://github.com/user-attachments/assets/081bae39-b569-4e0d-9066-4b1191ad26d9" />

_Permissions_
<img width="917" height="800" alt="image" src="https://github.com/user-attachments/assets/f4b0773c-17b1-4cbb-91b3-712b5109f8ef" />

_Bookings_
<img width="914" height="797" alt="image" src="https://github.com/user-attachments/assets/f88c364d-cf08-4c30-82df-a946a21f8b03" />

Closes #101 
