### PR TITLE
[RESOURCE APP][BACKEND] Refactor Database by Removing Auto-Migration Logic and Switch to Scripts

### DIFF
--- a/resource-app/backend/internal/config/config.go
+++ b/resource-app/backend/internal/config/config.go
@@ -7,7 +7,6 @@ import (
 const (
 	ServiceName = "resource-app"
 	DefaultPort = "8082"
-	AutoMigrate = false
 
 	// Database defaults
 	DefaultDatabaseURL = "root:password@tcp(localhost:3306)/resource_app?charset=utf8mb4&parseTime=True&loc=Local"

--- a/resource-app/backend/internal/db/db.go
+++ b/resource-app/backend/internal/db/db.go
@@ -4,15 +4,11 @@ import (
 	"log"
 	"time"
 
-	"resource-app/internal/booking"
-	"resource-app/internal/config"
-	"resource-app/internal/group"
-	"resource-app/internal/permission"
-	"resource-app/internal/resource"
-	"resource-app/internal/user"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
+
+	"resource-app/internal/config"
 )
 
 // NewDatabase creates a new database connection
@@ -25,13 +21,6 @@ func NewDatabase(dsn string) (*gorm.DB, error) {
 		return nil, err
 	}
 
-	if config.AutoMigrate {
-		// Auto-migrate models
-		if err := db.AutoMigrate(&user.User{}, &resource.Resource{}, &booking.Booking{}, &group.Group{}, &group.UserGroup{}, &permission.ResourcePermission{}); err != nil {
-			return nil, err
-		}
-	}
-
 	// Configure connection pool
 	if sqlDB, err := db.DB(); err == nil {
 		sqlDB.SetConnMaxLifetime(time.Duration(config.ConnMaxLifetimeMinutes) * time.Minute)
@@ -39,10 +28,6 @@ func NewDatabase(dsn string) (*gorm.DB, error) {
 		sqlDB.SetMaxOpenConns(config.MaxOpenConns)
 	}
 
-	if config.AutoMigrate {
-		log.Println("Database connection established and schema migrated successfully")
-	} else {
-		log.Println("Database connection established without auto-migration")
-	}
+	log.Println("Database connection established successfully")
 	return db, nil
 }


### PR DESCRIPTION
## Summary
Standardize database schema management by fully removing `AutoMigrate` usage and relying entirely on explicit migration scripts.

## Why
Schema structure, relationships, and constraints should be intentionally defined and version-controlled through migration files rather than being implicitly managed at runtime.

This improves:
- **Schema consistency** across environments.
- **Visibility** of database changes.
- **Control** over foreign keys and constraints.
- **Maintainability** of the backend.

## Proposed Changes
- **Remove AutoMigrate**: Stripped `AutoMigrate` logic from db.go and removed the configuration flag from config.go.
- **Explicit Migrations**: Ensured the backend startup flow only establishes a connection, leaving schema management to the SQL scripts in migrations.
- **Standardized Evolution**: Established a workflow where future schema changes are applied through reviewed versioned migration files.

## Acceptance Criteria
- [x] AutoMigrate-related code is removed from the backend.
- [x] Database schema creation is handled only through migration scripts.
- [x] Table relationships are explicitly defined in migration files.
- [x] Constraints and foreign keys are explicitly managed through migrations.
- [x] Schema behavior is consistent across environments.
- [x] Future schema changes can be applied without relying on runtime AutoMigrate.

## Note
Current migration scripts are written for **MySQL**.


Closes #123 
