### PR TITLE
[RESOURCE APP][BACKEND] Add Current User Groups Endpoint `GET /me/groups`

### DIFF
--- a/resource-app/backend/api/group.yaml
+++ b/resource-app/backend/api/group.yaml
@@ -344,8 +344,74 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  /me/groups:
+    get:
+      summary: Get current user's groups
+      description: Retrieve the authenticated user's groups using identity from auth context. Returns only group id and name.
+      operationId: getMyGroups
+      tags:
+        - Group Membership
+      security:
+        - BearerAuth: []
+      responses:
+        "200":
+          description: Successfully retrieved current user's groups
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/GroupSummary"
+              examples:
+                hasGroups:
+                  summary: User belongs to two groups
+                  value:
+                    success: true
+                    data:
+                      - id: "550e8400-e29b-41d4-a716-446655440100"
+                        name: "Engineering Team"
+                      - id: "550e8400-e29b-41d4-a716-446655440101"
+                        name: "Approvers"
+                noGroups:
+                  summary: User has no groups
+                  value:
+                    success: true
+                    data: []
+        "401":
+          description: User not authenticated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Failed to fetch current user's groups
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
 components:
   schemas:
+    GroupSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique group identifier
+        name:
+          type: string
+          description: Name of the group
+      required:
+        - id
+        - name
+
     Group:
       type: object
       properties:

--- a/resource-app/backend/cmd/server/main.go
+++ b/resource-app/backend/cmd/server/main.go
@@ -112,6 +112,7 @@ func main() {
 	user.RegisterRoutes(apiGroup, userService)
 
 	// Groups
+	apiGroup.GET("/me/groups", group.HandleGetMyGroups(groupService))
 	adminGroup.POST("/groups", group.HandleCreateGroup(groupService))
 	adminGroup.GET("/groups", group.HandleGetGroups(groupService))
 	adminGroup.PATCH("/groups/:id", group.HandleUpdateGroup(groupService))
@@ -156,7 +157,6 @@ func main() {
 	// Start server
 	port := config.GetEnv("PORT", config.DefaultPort)
 	log.Printf("Starting %s on port %s", config.ServiceName, port)
-
 
 	if err := r.Run(":" + port); err != nil {
 		log.Fatalf("Failed to run server: %v", err)

--- a/resource-app/backend/internal/group/handlers.go
+++ b/resource-app/backend/internal/group/handlers.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"log"
 	"net/http"
+	"resource-app/internal/auth"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -183,5 +184,23 @@ func HandleGetGroupMembers(svc *Service) gin.HandlerFunc {
 		}
 
 		c.JSON(http.StatusOK, gin.H{"success": true, "data": members})
+	}
+}
+
+func HandleGetMyGroups(svc *Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		currentUser := auth.GetUserFromContext(c)
+		if currentUser == nil {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
+			return
+		}
+
+		groups, err := svc.GetGroupsForUser(currentUser.ID)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch user groups"})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"success": true, "data": groups})
 	}
 }

--- a/resource-app/backend/internal/group/models.go
+++ b/resource-app/backend/internal/group/models.go
@@ -61,3 +61,8 @@ type GroupMemberResult struct {
 	Name  string `json:"name"`
 	Email string `json:"email"`
 }
+
+type GetMyGroupsResult struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}

--- a/resource-app/backend/internal/group/repository.go
+++ b/resource-app/backend/internal/group/repository.go
@@ -16,6 +16,7 @@ var ErrGroupNameDuplicate = errors.New("group name already exists")
 type Repository interface {
 	CreateGroup(createGroup *CreateGroupPayload) (*CreateGroupResult, error)
 	GetGroups() ([]Group, error)
+	GetGroupsForUser(userID string) ([]GetMyGroupsResult, error)
 	UpdateGroup(id string, updateGroup *UpdateGroupPayload) error
 	DeleteGroup(id string) error
 	AddUsersToGroup(groupID string, userIDs []string) (*AddUsersToGroupResult, error)
@@ -92,6 +93,22 @@ func (r *GormRepository) GetGroups() ([]Group, error) {
 	var groups []Group
 	result := r.db.Find(&groups)
 	return groups, result.Error
+}
+
+func (r *GormRepository) GetGroupsForUser(userID string) ([]GetMyGroupsResult, error) {
+	groups := make([]GetMyGroupsResult, 0)
+	err := r.db.Table("groups AS g").
+		Select("g.id, g.name").
+		Joins("JOIN user_groups ug ON ug.group_id = g.id").
+		Where("ug.user_id = ?", userID).
+		Order("g.name ASC").
+		Order("g.id ASC").
+		Scan(&groups).Error
+	if err != nil {
+		return nil, err
+	}
+
+	return groups, nil
 }
 
 func (r *GormRepository) UpdateGroup(id string, updateGroup *UpdateGroupPayload) error {

--- a/resource-app/backend/internal/group/services.go
+++ b/resource-app/backend/internal/group/services.go
@@ -2,7 +2,6 @@ package group
 
 import "resource-app/internal/utils"
 
-
 type Service struct {
 	repo Repository
 }
@@ -20,6 +19,10 @@ func (s *Service) CreateGroup(createGroup *CreateGroupPayload) (*CreateGroupResu
 
 func (s *Service) GetGroups() ([]Group, error) {
 	return s.repo.GetGroups()
+}
+
+func (s *Service) GetGroupsForUser(userID string) ([]GetMyGroupsResult, error) {
+	return s.repo.GetGroupsForUser(userID)
 }
 
 func (s *Service) UpdateGroup(id string, updateGroup *UpdateGroupPayload) error {


### PR DESCRIPTION
### **Description**

This PR adds a self-scoped endpoint for authenticated users to retrieve the groups they belong to without exposing arbitrary user lookups.

The new endpoint is `GET /api/me/groups`. It resolves the current user from auth context, queries memberships through the existing user_groups relationship, and returns only the group id and name. When the user has no groups, the response now returns an empty array.
#
### **What Changed**

- Added GET /api/me/groups for authenticated users.
- Resolved the current user only from request auth context.
- Reused the existing group membership data model to fetch the user’s groups.
- Returned a minimal response shape containing only id and name.
- Ensured empty results serialize as an empty array instead of null.
- Updated the OpenAPI documentation to match the endpoint behavior and response shape.

### **Behavior**

- Authenticated requests return only the logged-in user’s groups.
- Unauthenticated requests return 401.
- The endpoint does not accept user ID overrides in the path or query string.
- Response items contain only:
  - id
  - name

### **Verification**

- go test ./...
- Manual check of GET /api/me/groups with an authenticated user
- Manual check of GET /api/me/groups when the user has no memberships

<img width="919" height="778" alt="image" src="https://github.com/user-attachments/assets/3834544a-bc21-4990-ac73-5a1a9fc025e5" />



_Manual check of GET /api/me/groups when the user has no memberships_
<img width="920" height="674" alt="image" src="https://github.com/user-attachments/assets/d7f60537-4253-4af6-a244-e3e2502dc0ee" />

Closes #130

