### PR TITLE
[RESOURCE APP][BACKEND][FEAT] Add Endpoint for Retrieving REQUEST Groups for a Specific Resource

### DIFF
--- a/resource-app/backend/api/permission.yaml
+++ b/resource-app/backend/api/permission.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Permission Domain API
-  description: API endpoints for managing resource permissions and group access control in the resource-app. All endpoints in this domain require Admin privileges.
+  description: API endpoints for managing resource permissions and group access control in the resource-app. Most endpoints in this domain require Admin privileges; request-group visibility is available to any authenticated user.
   version: 1.0.0
 
 servers:
@@ -259,6 +259,49 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  /resources/{id}/request-groups:
+    get:
+      summary: Get request-allowed groups for a resource
+      description: Returns only groups that have REQUEST permission for the specified resource. This endpoint is available to any authenticated user.
+      operationId: getResourceRequestGroups
+      tags:
+        - Permissions
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Resource ID
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Successfully retrieved request-allowed groups
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: "#/components/schemas/ResourceRequestGroupsResponse"
+        "404":
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Failed to fetch allowed request groups
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
 components:
   schemas:
     ResourcePermission:
@@ -331,6 +374,36 @@ components:
           type: string
           enum: [REQUEST, APPROVE]
           description: Type of permission granted to the group
+
+    RequestGroupSummary:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Group ID
+        name:
+          type: string
+          description: Group name
+      required:
+        - id
+        - name
+
+    ResourceRequestGroupsResponse:
+      type: object
+      properties:
+        resourceId:
+          type: string
+          format: uuid
+          description: ID of the resource
+        allowedRequestGroups:
+          type: array
+          description: Groups that can request/book this resource
+          items:
+            $ref: "#/components/schemas/RequestGroupSummary"
+      required:
+        - resourceId
+        - allowedRequestGroups
 
     CreatePermissionRequest:
       type: object

--- a/resource-app/backend/cmd/server/main.go
+++ b/resource-app/backend/cmd/server/main.go
@@ -129,6 +129,7 @@ func main() {
 
 	// Resources
 	apiGroup.GET("/resources", resource.HandleGetResources(resourceService))
+	apiGroup.GET("/resources/:id/request-groups", permission.HandleGetResourceRequestGroups(permissionService))
 	adminGroup.POST("/resources", resource.HandleAddResource(resourceService))
 	adminGroup.PUT("/resources/:id", resource.HandleUpdateResource(resourceService))
 	adminGroup.DELETE("/resources/:id", resource.HandleDeleteResource(resourceService))

--- a/resource-app/backend/internal/permission/handlers.go
+++ b/resource-app/backend/internal/permission/handlers.go
@@ -158,6 +158,6 @@ func HandleGetResourceRequestGroups(svc *Service) gin.HandlerFunc {
 		}
 
 		// Keep response minimal for UI visibility use-cases.
-		c.JSON(http.StatusOK, requestGroups)
+		c.JSON(http.StatusOK, gin.H{"success": true, "data": requestGroups})
 	}
 }

--- a/resource-app/backend/internal/permission/handlers.go
+++ b/resource-app/backend/internal/permission/handlers.go
@@ -3,6 +3,7 @@ package permission
 import (
 	"errors"
 	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 )
@@ -138,5 +139,25 @@ func HandleGetResourcePermissions(svc *Service) gin.HandlerFunc {
 		}
 
 		c.JSON(http.StatusOK, gin.H{"success": true, "data": permissions})
+	}
+}
+
+func HandleGetResourceRequestGroups(svc *Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		resourceID := c.Param("id")
+
+		requestGroups, err := svc.GetRequestGroupsByResourceID(c.Request.Context(), resourceID)
+		if err != nil {
+			switch {
+			case errors.Is(err, ErrResourceNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"error": ErrResourceNotFound.Error()})
+			default:
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch allowed request groups"})
+			}
+			return
+		}
+
+		// Keep response minimal for UI visibility use-cases.
+		c.JSON(http.StatusOK, requestGroups)
 	}
 }

--- a/resource-app/backend/internal/permission/models.go
+++ b/resource-app/backend/internal/permission/models.go
@@ -38,3 +38,13 @@ type ResourcePermissionResult struct {
 	GroupName      string         `json:"groupName"`
 	PermissionType PermissionType `json:"permissionType"`
 }
+
+type RequestGroupSummary struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type ResourceRequestGroupsResponse struct {
+	ResourceID           string                `json:"resourceId"`
+	AllowedRequestGroups []RequestGroupSummary `json:"allowedRequestGroups"`
+}

--- a/resource-app/backend/internal/permission/repository.go
+++ b/resource-app/backend/internal/permission/repository.go
@@ -14,6 +14,7 @@ type Repository interface {
 	DeletePermission(id string) error
 	GetPermissionsByGroupID(ctx context.Context, groupID string) ([]GroupPermissionResult, error)
 	GetPermissionsByResourceID(ctx context.Context, resourceID string) ([]ResourcePermissionResult, error)
+	GetRequestGroupsByResourceID(ctx context.Context, resourceID string) (*ResourceRequestGroupsResponse, error)
 	HasUserPermissionForResource(userID, resourceID string, permissionType PermissionType) (bool, error)
 }
 
@@ -139,6 +140,36 @@ func (r *GormRepository) GetPermissionsByResourceID(ctx context.Context, resourc
 	}
 
 	return permissions, nil
+}
+
+func (r *GormRepository) GetRequestGroupsByResourceID(ctx context.Context, resourceID string) (*ResourceRequestGroupsResponse, error) {
+	var groups []RequestGroupSummary
+	err := r.db.WithContext(ctx).
+		Table("resource_permissions AS rp").
+		Select("g.id, g.name").
+		Joins("JOIN `groups` AS g ON g.id = rp.group_id").
+		Where("rp.resource_id = ? AND rp.permission_type = ?", resourceID, PermissionTypeRequest).
+		Order("g.name ASC").
+		Scan(&groups).Error
+	if err != nil {
+		return nil, err
+	}
+
+	if len(groups) == 0 {
+		var resourceCount int64
+		if err := r.db.WithContext(ctx).Table("resources").Where("id = ?", resourceID).Count(&resourceCount).Error; err != nil {
+			return nil, err
+		}
+		if resourceCount == 0 {
+			return nil, ErrResourceNotFound
+		}
+		groups = make([]RequestGroupSummary, 0)
+	}
+
+	return &ResourceRequestGroupsResponse{
+		ResourceID:           resourceID,
+		AllowedRequestGroups: groups,
+	}, nil
 }
 
 func isDuplicateKeyError(err error) bool {

--- a/resource-app/backend/internal/permission/services.go
+++ b/resource-app/backend/internal/permission/services.go
@@ -2,6 +2,7 @@ package permission
 
 import (
 	"context"
+
 	"github.com/google/uuid"
 )
 
@@ -40,6 +41,10 @@ func (s *Service) GetPermissionsByGroupID(ctx context.Context, groupID string) (
 
 func (s *Service) GetPermissionsByResourceID(ctx context.Context, resourceID string) ([]ResourcePermissionResult, error) {
 	return s.repo.GetPermissionsByResourceID(ctx, resourceID)
+}
+
+func (s *Service) GetRequestGroupsByResourceID(ctx context.Context, resourceID string) (*ResourceRequestGroupsResponse, error) {
+	return s.repo.GetRequestGroupsByResourceID(ctx, resourceID)
 }
 
 func (s *Service) HasRequestPermission(userID, resourceID string) (bool, error) {


### PR DESCRIPTION
## Description

This PR adds a new read-only backend endpoint to expose which groups are allowed to request/book a specific resource. It supports the frontend  _"Who can book this?"_  flow by returning only the groups with REQUEST permission for a resource, without requiring the current user to personally have booking access.

## What changed
- Added GET /api/resources/:id/request-groups
- The endpoint is available to authenticated users, not admin-only
- The response returns only resourceId and allowedRequestGroups
- Each returned group includes only id and name
- The query filters resource permissions to REQUEST only
- Existing admin permission endpoints remain unchanged

## Response shape
```json
{
  "resourceId": "resource-id-1",
  "allowedRequestGroups": [
    {
      "id": "group-id-1",
      "name": "Level 1 Officers"
    },
    {
      "id": "group-id-2",
      "name": "Level 2 Officers"
    }
  ]
}
```

## Behavior
- Returns 200 with an empty allowedRequestGroups array when no groups have REQUEST permission
- Returns 404 when the resource does not exist
- Returns minimal data safe for UI visibility purposes

## Verification
- Ran backend test suite successfully
- Confirmed no compile or lint errors in the changed backend files
- Preserved existing permission management and admin routes



<img width="926" height="807" alt="Screenshot 2026-04-07 174331" src="https://github.com/user-attachments/assets/9ebae538-c950-41d7-b147-d622ba45ef78" />

_Resources with no REQUEST groups_
<img width="916" height="766" alt="image" src="https://github.com/user-attachments/assets/22e84334-869c-4184-9a52-c1e0f9e090dc" />

closes #131 