### PR TITLE
[RESOURCE APP][BACKEND][FEAT] Add Endpoint for Fetching Bookings with Status-Pending

### DIFF
--- a/resource-app/backend/api/booking.yaml
+++ b/resource-app/backend/api/booking.yaml
@@ -106,6 +106,43 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  /bookings/pending-approvals:
+    get:
+      summary: Get bookings pending approval for the current user
+      description: Retrieve pending bookings for resources where the authenticated user has APPROVE permission via group membership
+      operationId: getPendingApprovalBookings
+      tags:
+        - Bookings
+      security:
+        - BearerAuth: []
+      responses:
+        "200":
+          description: Successfully retrieved pending approval bookings
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Booking"
+        "401":
+          description: User not authenticated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Failed to fetch pending approvals
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   /bookings/{id}/process:
     patch:
       summary: Process/update booking status

--- a/resource-app/backend/cmd/server/main.go
+++ b/resource-app/backend/cmd/server/main.go
@@ -135,6 +135,7 @@ func main() {
 
 	// Bookings
 	apiGroup.GET("/bookings", booking.HandleGetBookings(bookingService))
+	apiGroup.GET("/bookings/pending-approvals", booking.HandleGetPendingApprovals(bookingService))
 	apiGroup.POST("/bookings", booking.HandleCreateBooking(bookingService))
 	apiGroup.PATCH("/bookings/:id/process", booking.HandleProcessBooking(bookingService)) //booking status update (confirm/reject)
 	apiGroup.PATCH("/bookings/:id/reschedule", booking.HandleRescheduleBooking(bookingService))
@@ -156,7 +157,6 @@ func main() {
 	// Start server
 	port := config.GetEnv("PORT", config.DefaultPort)
 	log.Printf("Starting %s on port %s", config.ServiceName, port)
-
 
 	if err := r.Run(":" + port); err != nil {
 		log.Fatalf("Failed to run server: %v", err)

--- a/resource-app/backend/internal/booking/constants.go
+++ b/resource-app/backend/internal/booking/constants.go
@@ -16,9 +16,9 @@ const (
 )
 
 var (
-	ErrResourceNotFound       = errors.New("resource not found")
-	ErrBookingNotFound        = errors.New("booking not found")
-	ErrBookingConflict        = errors.New("booking conflict: time slot is already booked")
-	ErrRescheduleSlotConflict = errors.New("reschedule conflict: new time slot is already booked")
+	ErrResourceNotFound        = errors.New("resource not found")
+	ErrBookingNotFound         = errors.New("booking not found")
+	ErrBookingConflict         = errors.New("booking conflict: time slot is already booked")
+	ErrRescheduleSlotConflict  = errors.New("reschedule conflict: new time slot is already booked")
 	ErrBookingPermissionDenied = errors.New("permission denied: insufficient permissions to book this resource")
 )

--- a/resource-app/backend/internal/booking/handlers.go
+++ b/resource-app/backend/internal/booking/handlers.go
@@ -20,6 +20,24 @@ func HandleGetBookings(svc *Service) gin.HandlerFunc {
 	}
 }
 
+func HandleGetPendingApprovals(svc *Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		user := auth.GetUserFromContext(c)
+		if user == nil {
+			c.JSON(http.StatusUnauthorized, gin.H{"success": false, "error": "User not authenticated"})
+			return
+		}
+
+		bookings, err := svc.GetPendingApprovalBookings(user.ID)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "Failed to fetch pending approvals"})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"success": true, "data": bookings})
+	}
+}
+
 func HandleCreateBooking(svc *Service) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var req Booking
@@ -140,4 +158,3 @@ func HandleGetStats(svc *Service) gin.HandlerFunc {
 		c.JSON(http.StatusOK, gin.H{"success": true, "data": stats})
 	}
 }
-

--- a/resource-app/backend/internal/booking/repository.go
+++ b/resource-app/backend/internal/booking/repository.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"time"
 
+	perm "resource-app/internal/permission"
+
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -22,6 +24,7 @@ type utilizationRow struct {
 
 type Repository interface {
 	GetBookings() ([]Booking, error)
+	GetPendingApprovalBookings(userID string) ([]Booking, error)
 	CreateBooking(booking *Booking) error
 	UpdateBookingStatus(id string, status BookingStatus, rejectionReason *string) (*Booking, error)
 	RescheduleBooking(id string, newStart, newEnd time.Time) (*Booking, error)
@@ -42,6 +45,25 @@ func NewGormRepository(db *gorm.DB) *GormRepository {
 func (r *GormRepository) GetBookings() ([]Booking, error) {
 	var bookings []Booking
 	result := r.db.Find(&bookings)
+	return bookings, result.Error
+}
+
+func (r *GormRepository) GetPendingApprovalBookings(userID string) ([]Booking, error) {
+	var bookings []Booking
+
+	resourceScope := r.db.
+		Table("resource_permissions rp").
+		Select("DISTINCT rp.resource_id").
+		Joins("JOIN user_groups ug ON ug.group_id = rp.group_id").
+		Where("ug.user_id = ? AND rp.permission_type = ?", userID, perm.PermissionTypeApprove)
+
+	result := r.db.
+		Model(&Booking{}).
+		Where("status = ?", StatusPending).
+		Where("resource_id IN (?)", resourceScope).
+		Order("start ASC").
+		Find(&bookings)
+
 	return bookings, result.Error
 }
 
@@ -144,8 +166,8 @@ func (r *GormRepository) RescheduleBooking(id string, newStart, newEnd time.Time
 				newStart,
 			).
 			Count(&count).Error; err != nil {
-				return err
-			}
+			return err
+		}
 
 		if count > 0 {
 			return ErrRescheduleSlotConflict
@@ -225,4 +247,3 @@ func (r *GormRepository) GetUtilizationStats() ([]ResourceUsageStats, error) {
 
 	return stats, nil
 }
-

--- a/resource-app/backend/internal/booking/services.go
+++ b/resource-app/backend/internal/booking/services.go
@@ -10,19 +10,23 @@ import (
 )
 
 type Service struct {
-	repo            Repository
-	permissionSvc   *perm.Service
+	repo          Repository
+	permissionSvc *perm.Service
 }
 
 func NewService(repo Repository, permissionSvc *perm.Service) *Service {
 	return &Service{
-		repo:            repo,
-		permissionSvc:   permissionSvc,
+		repo:          repo,
+		permissionSvc: permissionSvc,
 	}
 }
 
 func (s *Service) GetBookings() ([]Booking, error) {
 	return s.repo.GetBookings()
+}
+
+func (s *Service) GetPendingApprovalBookings(userID string) ([]Booking, error) {
+	return s.repo.GetPendingApprovalBookings(userID)
 }
 
 func (s *Service) CreateBooking(booking *Booking, userID string, userRole usr.Role) error {


### PR DESCRIPTION
### Summary
This endpoint returns only pending bookings for resources where the authenticated user has `APPROVE` permission through one of their groups, so approval officers only see bookings they are allowed to review.

### What changed
- Added `GET /api/bookings/pending-approvals` route in main.go
- Implemented `GetPendingApprovalBookings(userID string)` in repository.go
- Added service passthrough in services.go
- Added handler `HandleGetPendingApprovals` in handlers.go
- Updated API documentation in booking.yaml

### Behavior
- Filters by booking status `pending`
- Scopes resources via `user_groups` → `resource_permissions` with `APPROVE`
- Returns an empty list when the user has no approve-scoped resources
- Uses authenticated user context for permission scoping

_If there are bookings that current user can approve_
<img width="903" height="724" alt="Screenshot 2026-04-08 145153" src="https://github.com/user-attachments/assets/10fa7a05-b687-43cd-8c44-54ea385e5dd0" />

_If there are no any bookings that current user can approve_
<img width="918" height="514" alt="Screenshot 2026-04-08 145456" src="https://github.com/user-attachments/assets/36b99fd2-4c00-4a4a-a26e-f45f0457c207" />

closes #132 
