### PR TITLE
[RESOURCE APP][BACKEND][FEAT] Implement Approvable Booking Scope on `GET /bookings`

### DIFF
--- a/resource-app/backend/api/booking.yaml
+++ b/resource-app/backend/api/booking.yaml
@@ -498,10 +498,15 @@ components:
     ErrorResponse:
       type: object
       properties:
+        success:
+          type: boolean
+          description: Indicates the request failed
+          example: false
         error:
           type: string
           description: Error message
       required:
+        - success
         - error
 
   securitySchemes:

--- a/resource-app/backend/internal/booking/constants.go
+++ b/resource-app/backend/internal/booking/constants.go
@@ -20,5 +20,6 @@ var (
 	ErrBookingNotFound        = errors.New("booking not found")
 	ErrBookingConflict        = errors.New("booking conflict: time slot is already booked")
 	ErrRescheduleSlotConflict = errors.New("reschedule conflict: new time slot is already booked")
+	ErrBookingViewPermissionDenied = errors.New("permission denied: insufficient permissions to view bookings for this resource")
 	ErrBookingPermissionDenied = errors.New("permission denied: insufficient permissions to book this resource")
 )

--- a/resource-app/backend/internal/booking/handlers.go
+++ b/resource-app/backend/internal/booking/handlers.go
@@ -49,7 +49,12 @@ func HandleGetBookings(svc *Service) gin.HandlerFunc {
 
 		bookings, err := svc.GetBookings(filter)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "Failed to fetch bookings"})
+			switch {
+			case errors.Is(err, ErrBookingViewPermissionDenied):
+				c.JSON(http.StatusForbidden, gin.H{"success": false, "error": ErrBookingViewPermissionDenied.Error()})
+			default:
+				c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "Failed to fetch bookings"})
+			}
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"success": true, "data": bookings})

--- a/resource-app/backend/internal/booking/models.go
+++ b/resource-app/backend/internal/booking/models.go
@@ -9,7 +9,7 @@ import (
 type Booking struct {
 	ID              string          `json:"id" gorm:"primaryKey;type:varchar(36)"`
 	ResourceID      string          `json:"resourceId" gorm:"index;type:varchar(36);not null"`
-	UserID          string          `json:"userId" gorm:"index;type:varchar(36);not null"`
+	UserID          string          `json:"userId" gorm:"index;type:varchar(36);not null"` // The user who made the booking
 	Start           time.Time       `json:"start" gorm:"not null"`
 	End             time.Time       `json:"end" gorm:"not null"`
 	Status          BookingStatus   `json:"status" gorm:"index;type:varchar(20);default:'pending'"`

--- a/resource-app/backend/internal/booking/services.go
+++ b/resource-app/backend/internal/booking/services.go
@@ -1,6 +1,7 @@
 package booking
 
 import (
+	"slices"
 	"time"
 
 	perm "resource-app/internal/permission"
@@ -23,13 +24,38 @@ func NewService(repo Repository, permissionSvc *perm.Service) *Service {
 
 func (s *Service) GetBookings(filter BookingFilter) ([]Booking, error) {
 	var userID *string
-	if filter.Scope == BookingScopeMe {
-		userID = &filter.CurrentUserID
-	}
-
 	var resourceIDs []string
+
+	// Apply generic resource filter first so it works even when scope is omitted.
 	if filter.ResourceID != "" {
 		resourceIDs = []string{filter.ResourceID}
+	}
+
+	switch filter.Scope {
+	// "me" scope: only return bookings made by the current user.
+	case BookingScopeMe:
+		userID = &filter.CurrentUserID
+
+	// "approvable" scope: return bookings for resources the user has APPROVE permission on.
+	case BookingScopeApprovable:
+		approvableResourceIDs, err := s.permissionSvc.GetApprovableResourceIDs(filter.CurrentUserID)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(approvableResourceIDs) == 0 {
+			return []Booking{}, nil
+		}
+
+		if filter.ResourceID != "" {
+			// If a specific resource is requested, it must be approvable by this user.
+			if !slices.Contains(approvableResourceIDs, filter.ResourceID) {
+				return nil, ErrBookingViewPermissionDenied
+			}
+		} else {
+			// No specific resource requested: return bookings from all approvable resources.
+			resourceIDs = approvableResourceIDs
+		}
 	}
 
 	return s.repo.GetBookings(userID, filter.Statuses, resourceIDs)


### PR DESCRIPTION
### **PR Description**
This PR is focused on adding approver-scoped booking retrieval to the existing bookings list endpoint. Instead of introducing a new route, the booking list now supports `scope=approvable` and filters bookings to resources the authenticated user can approve through group-based `APPROVE` permissions.

### **What changed**
- Updated the booking service to pass scope-aware booking filters through the existing flow.
- Updated the booking repository to query approvable resources through `user_groups` and `resource_permissions` using a single user identity.
- Kept `scope=me` behavior intact and preserved existing optional `status` and `resourceId` filters.
- Documented the approvable booking query behavior and examples in the booking OpenAPI contract.

### **Behavior**
- `GET /bookings?scope=me` returns bookings created by the authenticated user.
- `GET /bookings?scope=approvable` returns bookings for resources the authenticated user can approve.
- `status` and `resourceId` can be combined with either scope.
- No-scope requests continue to follow the current default behavior.

### **Validation**
- Backend compile check passed with `go test Desktop.`
- No compile or diagnostic errors in the touched booking files


<img width="913" height="751" alt="image" src="https://github.com/user-attachments/assets/0acea67c-80f0-43d4-b21f-c6f4a989e072" />
<img width="921" height="482" alt="image" src="https://github.com/user-attachments/assets/6f06ec70-07aa-4f9b-8d79-41458447ca35" />



closes #132 