### PR TITLE
[RESOURCE APP][BACKEND][FEAT] Expose Resource Requestability and Permission Group

### DIFF
--- a/resource-app/backend/api/permission.yaml
+++ b/resource-app/backend/api/permission.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Permission Domain API
-  description: API endpoints for managing resource permissions and group access control in the resource-app. All endpoints in this domain require Admin privileges.
+  description: API endpoints for managing resource permissions and group access control in the resource-app. Permission write endpoints require Admin privileges, while GET /resources/{id}/permissions is available to all authenticated users.
   version: 1.0.0
 
 servers:
@@ -217,7 +217,7 @@ paths:
   /resources/{id}/permissions:
     get:
       summary: Get resource permissions
-      description: Get all group permissions for a specific resource
+      description: Get group permissions for a specific resource. Supports optional filtering by permission type.
       operationId: getResourcePermissions
       tags:
         - Permissions
@@ -231,6 +231,16 @@ paths:
           schema:
             type: string
             format: uuid
+        - name: type
+          in: query
+          required: false
+          description: Optional permission type filter
+          schema:
+            type: string
+            enum:
+              - REQUEST
+              - APPROVE
+          example: REQUEST
       responses:
         "200":
           description: Successfully retrieved resource permissions
@@ -246,8 +256,25 @@ paths:
                     type: array
                     items:
                       $ref: "#/components/schemas/ResourcePermissionResult"
+              example:
+                success: true
+                data:
+                  - id: "7f9a7c0c-b745-4f21-88c0-5f0c5ef0f301"
+                    groupId: "f6af39f1-1a87-4f30-bc58-83b8ef2a0a10"
+                    groupName: "Operations"
+                    permissionType: "REQUEST"
+                  - id: "9a4b67a7-9d4d-4b3f-9a75-6d4d19f9d7d8"
+                    groupId: "d4fd7d1b-4f9d-4bb5-8b22-1c6f4eb0f4cd"
+                    groupName: "Facilities"
+                    permissionType: "REQUEST"
         "404":
           description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "400":
+          description: Invalid resource ID or permission type
           content:
             application/json:
               schema:

--- a/resource-app/backend/api/resource.yaml
+++ b/resource-app/backend/api/resource.yaml
@@ -14,7 +14,7 @@ paths:
   /resources:
     get:
       summary: Get all resources
-      description: Retrieve a list of all available resources
+      description: Retrieve a list of all available resources with requestability metadata for the authenticated user
       operationId: getResources
       tags:
         - Resources
@@ -34,7 +34,38 @@ paths:
                   data:
                     type: array
                     items:
-                      $ref: "#/components/schemas/Resource"
+                      $ref: "#/components/schemas/ResourceListItem"
+              example:
+                success: true
+                data:
+                  - id: "b7c7f7f6-8e2f-4cd7-8f6a-8d5fae0f2a01"
+                    name: "Conference Room A"
+                    type: "room"
+                    description: "Large conference room with AV equipment"
+                    isActive: true
+                    minLeadTimeHours: 2
+                    icon: "conference-room"
+                    color: "#FF5733"
+                    specs:
+                      capacity: 20
+                      hasVideo: true
+                    formFields: {}
+                    createdAt: "2026-04-16T10:00:00Z"
+                    updatedAt: "2026-04-16T10:00:00Z"
+                    canBook: true
+                  - id: "a91d0e1e-1eb5-4f9c-8a5b-7ec0f2b8b111"
+                    name: "Projector"
+                    type: "equipment"
+                    description: "Portable projector"
+                    isActive: true
+                    minLeadTimeHours: 1
+                    icon: "projector"
+                    color: "#1F2937"
+                    specs: {}
+                    formFields: {}
+                    createdAt: "2026-04-16T10:00:00Z"
+                    updatedAt: "2026-04-16T10:00:00Z"
+                    canBook: false
         "500":
           description: Failed to fetch resources
           content:
@@ -209,6 +240,17 @@ components:
         - id
         - name
         - type
+
+    ResourceListItem:
+      allOf:
+        - $ref: "#/components/schemas/Resource"
+        - type: object
+          properties:
+            canBook:
+              type: boolean
+              description: Whether the authenticated user can request this resource
+          required:
+            - canBook
 
     CreateResourceRequest:
       type: object

--- a/resource-app/backend/cmd/server/main.go
+++ b/resource-app/backend/cmd/server/main.go
@@ -126,10 +126,10 @@ func main() {
 	adminGroup.PATCH("/resource-permissions/:id", permission.HandleUpdatePermissionType(permissionService))
 	adminGroup.DELETE("/resource-permissions/:id", permission.HandleDeletePermission(permissionService))
 	adminGroup.GET("/groups/:id/permissions", permission.HandleGetGroupPermissions(permissionService))
-	adminGroup.GET("/resources/:id/permissions", permission.HandleGetResourcePermissions(permissionService))
 
 	// Resources
 	apiGroup.GET("/resources", resource.HandleGetResources(resourceService))
+	apiGroup.GET("/resources/:id/permissions", permission.HandleGetResourcePermissions(permissionService))
 	adminGroup.POST("/resources", resource.HandleAddResource(resourceService))
 	adminGroup.PUT("/resources/:id", resource.HandleUpdateResource(resourceService))
 	adminGroup.DELETE("/resources/:id", resource.HandleDeleteResource(resourceService))

--- a/resource-app/backend/internal/permission/handlers.go
+++ b/resource-app/backend/internal/permission/handlers.go
@@ -3,6 +3,7 @@ package permission
 import (
 	"errors"
 	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 )
@@ -126,7 +127,17 @@ func HandleGetResourcePermissions(svc *Service) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		resourceID := c.Param("id")
 
-		permissions, err := svc.GetPermissionsByResourceID(c.Request.Context(), resourceID)
+		var permissionType *PermissionType
+		if rawType := c.Query("type"); rawType != "" {
+			parsedType := PermissionType(rawType)
+			if !IsValidPermissionType(parsedType) {
+				c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "invalid permission type"})
+				return
+			}
+			permissionType = &parsedType
+		}
+
+		permissions, err := svc.GetPermissionsByResourceID(c.Request.Context(), resourceID, permissionType)
 		if err != nil {
 			switch {
 			case errors.Is(err, ErrResourceNotFound):

--- a/resource-app/backend/internal/permission/repository.go
+++ b/resource-app/backend/internal/permission/repository.go
@@ -13,8 +13,9 @@ type Repository interface {
 	UpdatePermissionType(id string, permissionType PermissionType) (*ResourcePermission, error)
 	DeletePermission(id string) error
 	GetPermissionsByGroupID(ctx context.Context, groupID string) ([]GroupPermissionResult, error)
-	GetPermissionsByResourceID(ctx context.Context, resourceID string) ([]ResourcePermissionResult, error)
+	GetPermissionsByResourceID(ctx context.Context, resourceID string, permissionType *PermissionType) ([]ResourcePermissionResult, error)
 	HasUserPermissionForResource(userID, resourceID string, permissionType PermissionType) (bool, error)
+	GetResourceIDsByUserPermission(userID string, permissionType PermissionType) ([]string, error)
 }
 
 type GormRepository struct {
@@ -115,14 +116,19 @@ func (r *GormRepository) GetPermissionsByGroupID(ctx context.Context, groupID st
 	return permissions, nil
 }
 
-func (r *GormRepository) GetPermissionsByResourceID(ctx context.Context, resourceID string) ([]ResourcePermissionResult, error) {
+func (r *GormRepository) GetPermissionsByResourceID(ctx context.Context, resourceID string, permissionType *PermissionType) ([]ResourcePermissionResult, error) {
 	var permissions []ResourcePermissionResult
-	err := r.db.WithContext(ctx).
+	query := r.db.WithContext(ctx).
 		Table("resource_permissions AS rp").
 		Select("rp.id, rp.group_id, g.name AS group_name, rp.permission_type").
 		Joins("JOIN `groups` AS g ON g.id = rp.group_id").
-		Where("rp.resource_id = ?", resourceID).
-		Order("g.name ASC, rp.permission_type ASC").
+		Where("rp.resource_id = ?", resourceID)
+
+	if permissionType != nil {
+		query = query.Where("rp.permission_type = ?", *permissionType)
+	}
+
+	err := query.Order("g.name ASC, rp.permission_type ASC").
 		Scan(&permissions).Error
 	if err != nil {
 		return nil, err
@@ -161,6 +167,21 @@ func (r *GormRepository) HasUserPermissionForResource(userID, resourceID string,
 		return false, err
 	}
 	return count > 0, nil
+}
+
+func (r *GormRepository) GetResourceIDsByUserPermission(userID string, permissionType PermissionType) ([]string, error) {
+	var resourceIDs []string
+	err := r.db.
+		Table("resource_permissions rp").
+		Distinct("rp.resource_id").
+		Joins("JOIN user_groups ug ON rp.group_id = ug.group_id").
+		Where("ug.user_id = ? AND rp.permission_type = ?", userID, permissionType).
+		Pluck("rp.resource_id", &resourceIDs).Error
+	if err != nil {
+		return nil, err
+	}
+
+	return resourceIDs, nil
 }
 
 func foreignKeyConstraintError(err error) (bool, string) {

--- a/resource-app/backend/internal/permission/services.go
+++ b/resource-app/backend/internal/permission/services.go
@@ -2,6 +2,7 @@ package permission
 
 import (
 	"context"
+
 	"github.com/google/uuid"
 )
 
@@ -38,8 +39,8 @@ func (s *Service) GetPermissionsByGroupID(ctx context.Context, groupID string) (
 	return s.repo.GetPermissionsByGroupID(ctx, groupID)
 }
 
-func (s *Service) GetPermissionsByResourceID(ctx context.Context, resourceID string) ([]ResourcePermissionResult, error) {
-	return s.repo.GetPermissionsByResourceID(ctx, resourceID)
+func (s *Service) GetPermissionsByResourceID(ctx context.Context, resourceID string, permissionType *PermissionType) ([]ResourcePermissionResult, error) {
+	return s.repo.GetPermissionsByResourceID(ctx, resourceID, permissionType)
 }
 
 func (s *Service) HasRequestPermission(userID, resourceID string) (bool, error) {
@@ -48,4 +49,8 @@ func (s *Service) HasRequestPermission(userID, resourceID string) (bool, error) 
 
 func (s *Service) HasApprovePermission(userID, resourceID string) (bool, error) {
 	return s.repo.HasUserPermissionForResource(userID, resourceID, PermissionTypeApprove)
+}
+
+func (s *Service) GetApprovableResourceIDs(userID string) ([]string, error) {
+	return s.repo.GetResourceIDsByUserPermission(userID, PermissionTypeApprove)
 }

--- a/resource-app/backend/internal/resource/handlers.go
+++ b/resource-app/backend/internal/resource/handlers.go
@@ -3,13 +3,20 @@ package resource
 import (
 	"errors"
 	"net/http"
+	"resource-app/internal/auth"
 
 	"github.com/gin-gonic/gin"
 )
 
 func HandleGetResources(svc *Service) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		resources, err := svc.GetResources()
+		user := auth.GetUserFromContext(c)
+		if user == nil {
+			c.JSON(http.StatusUnauthorized, gin.H{"success": false, "error": "User not authenticated"})
+			return
+		}
+
+		resources, err := svc.GetResources(user.ID)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch resources"})
 			return
@@ -72,7 +79,12 @@ func HandleDeleteResource(svc *Service) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		id := c.Param("id")
 		if err := svc.DeleteResource(id); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete resource"})
+			switch {
+			case errors.Is(err, ErrResourceNotFound):
+				c.JSON(http.StatusNotFound, gin.H{"success": false, "error": err.Error()})
+			default:
+				c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "Failed to delete resource"})
+			}
 			return
 		}
 		c.Status(http.StatusNoContent)

--- a/resource-app/backend/internal/resource/models.go
+++ b/resource-app/backend/internal/resource/models.go
@@ -19,3 +19,9 @@ type Resource struct {
 	CreatedAt        time.Time       `json:"createdAt" gorm:"autoCreateTime"`
 	UpdatedAt        time.Time       `json:"updatedAt" gorm:"autoUpdateTime"`
 }
+
+// ResourceListItem extends Resource with per-user requestability metadata.
+type ResourceListItem struct {
+	Resource
+	CanBook bool `json:"canBook" gorm:"column:can_book"`
+}

--- a/resource-app/backend/internal/resource/repository.go
+++ b/resource-app/backend/internal/resource/repository.go
@@ -2,6 +2,9 @@ package resource
 
 import (
 	"errors"
+
+	perm "resource-app/internal/permission"
+
 	"gorm.io/gorm"
 )
 
@@ -9,7 +12,7 @@ var ErrResourceNameDuplicate = errors.New("resource name already exists")
 var ErrResourceNotFound = errors.New("resource not found")
 
 type Repository interface {
-	GetResources() ([]Resource, error)
+	GetResources(currentUserID string) ([]ResourceListItem, error)
 	AddResource(resource *Resource) error
 	UpdateResource(resource *Resource) error
 	DeleteResource(id string) error
@@ -24,10 +27,21 @@ func NewGormRepository(db *gorm.DB) *GormRepository {
 	return &GormRepository{db: db}
 }
 
-func (r *GormRepository) GetResources() ([]Resource, error) {
-	var resources []Resource
-	result := r.db.Find(&resources)
-	return resources, result.Error
+func (r *GormRepository) GetResources(currentUserID string) ([]ResourceListItem, error) {
+	var resources []ResourceListItem
+
+	err := r.db.Model(&Resource{}).
+		Select("resources.*, CASE WHEN user_perms.resource_id IS NOT NULL THEN TRUE ELSE FALSE END AS can_book").
+		Joins(`LEFT JOIN (
+			SELECT DISTINCT rp.resource_id
+			FROM resource_permissions rp
+			JOIN user_groups ug ON ug.group_id = rp.group_id
+			WHERE rp.permission_type = ? AND ug.user_id = ?
+		) AS user_perms ON user_perms.resource_id = resources.id`, perm.PermissionTypeRequest, currentUserID).
+		Order("created_at DESC").
+		Scan(&resources).Error
+
+	return resources, err
 }
 
 func (r *GormRepository) AddResource(resource *Resource) error {

--- a/resource-app/backend/internal/resource/services.go
+++ b/resource-app/backend/internal/resource/services.go
@@ -14,8 +14,8 @@ func NewService(repo Repository) *Service {
 	return &Service{repo: repo}
 }
 
-func (s *Service) GetResources() ([]Resource, error) {
-	return s.repo.GetResources()
+func (s *Service) GetResources(currentUserID string) ([]ResourceListItem, error) {
+	return s.repo.GetResources(currentUserID)
 }
 
 func (s *Service) AddResource(resource *Resource) error {


### PR DESCRIPTION
### **Description**
This PR updates the resource backend so authenticated users can inspect resource permissions and the resource list includes per-user requestability metadata.

### **What changed**
- Moved the resource permissions read route from the admin-only group to the authenticated API group in cmd/server/main.go.
- Extended GET /resources/{id}/permissions to accept an optional type query parameter with values REQUEST or APPROVE in internal/permission/handlers.go.
- Updated the permission service and repository so the resource-permissions query can be filtered by permission type in internal/permission/services.go and internal/permission/repository.go.
- Extended GET /resources so each resource returns requestability metadata for the authenticated user via the new ResourceListItem response shape in internal/resource/models.go, internal/resource/services.go, and internal/resource/repository.go.
- Updated the OpenAPI docs for resource and permission endpoints in api/resource.yaml and api/permission.yaml.

### **Behavior**
- GET /resources continues to return all resources, but now includes canBook for each item.
- canBook is derived from REQUEST permission via group membership for the authenticated user.
- GET /resources/{id}/permissions is now available to authenticated users, not only admins.
- Passing type=REQUEST or type=APPROVE filters the returned permissions accordingly.
- Invalid resource IDs and invalid permission types return 400 responses.

**Validation**
- Ran go test ./... from backend successfully.

**_Permissions_**
<img width="897" height="755" alt="image" src="https://github.com/user-attachments/assets/a7992d25-ae47-47a1-9afd-71451fc96603" />
<img width="908" height="694" alt="image" src="https://github.com/user-attachments/assets/7400326d-b609-414d-aac9-b72eb5c5f92c" />
#
_**Resources**_
<img width="916" height="526" alt="image" src="https://github.com/user-attachments/assets/94616492-70cd-4eb5-9b77-26a64980408a" />
<img width="917" height="395" alt="image" src="https://github.com/user-attachments/assets/a5c0e6ef-67ee-4148-86e9-54f4f91fe431" />
<img width="925" height="388" alt="image" src="https://github.com/user-attachments/assets/c238640d-9259-493c-bab1-91694a0c88d4" />

closes #131 
