### PR TITLE
[ResourceApp][Backend][FEAT]: Implement `/api/users/me` endpoint

### DIFF
--- a/resource-app/backend/internal/auth/auth.go
+++ b/resource-app/backend/internal/auth/auth.go
@@ -178,12 +178,7 @@ func DevAuthMiddleware(userService UserService) gin.HandlerFunc {
 
 // GetUserFromContext retrieves the user object from the Gin context
 func GetUserFromContext(c *gin.Context) *user.User {
-	if u, exists := c.Get("user"); exists {
-		if uObj, ok := u.(*user.User); ok {
-			return uObj
-		}
-	}
-	return nil
+	return user.GetUserFromContext(c)
 }
 
 // RequireAdminMiddleware restricts access to users with ADMIN role.

--- a/resource-app/backend/internal/user/context.go
+++ b/resource-app/backend/internal/user/context.go
@@ -1,0 +1,13 @@
+package user
+
+import "github.com/gin-gonic/gin"
+
+// GetUserFromContext retrieves the user object from the Gin context
+func GetUserFromContext(c *gin.Context) *User {
+	if u, exists := c.Get("user"); exists {
+		if uObj, ok := u.(*User); ok {
+			return uObj
+		}
+	}
+	return nil
+}

--- a/resource-app/backend/internal/user/handlers.go
+++ b/resource-app/backend/internal/user/handlers.go
@@ -43,11 +43,24 @@ func HandleUpdateUserRole(service *Service) gin.HandlerFunc {
 		c.JSON(http.StatusOK, gin.H{"success": true, "data": updatedUser})
 	}
 }
+
+func HandleGetMe() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		currentUser := GetUserFromContext(c)
+		if currentUser == nil {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"success": true, "data": currentUser})
+	}
+}
+
 // RegisterRoutes registers the user routes
 func RegisterRoutes(rg *gin.RouterGroup, service *Service) {
 	users := rg.Group("/users")
 	{
 		users.GET("", HandleGetUsers(service))
+		users.GET("/me", HandleGetMe())
 		users.PATCH("/:id/role", HandleUpdateUserRole(service))
 	}
 }


### PR DESCRIPTION
## Overview
Currently, the frontend is forced to fetch the entire list of users via `/api/users` on startup just to identify the logged-in user's profile and role. This PR implements the `/api/users/me` endpoint to provide a direct way for the frontend to fetch the authenticated user's profile, improving efficiency and reducing unnecessary data exposure.

## Changes
- **Refactored Context Utility**: Moved `GetUserFromContext` from `internal/auth` to `internal/user/context.go`. This resolves circular dependency issues since the `user` package now needs this logic, while the `auth` package already depends on `user` for models.
- **Implemented Handler**: Added `HandleGetMe` in `internal/user/handlers.go` to retrieve the user from the context and return it in a standard `ApiResponse` format.
- **Added Route**: Registered `GET /api/users/me` within the authenticated user group.

## Success Criteria
- [x] Authenticated users can fetch their own profile.
- [x] Unauthenticated requests are rejected with a 401 (handled by `AuthMiddleware`).
- [x] User object is returned in the standard format: `{ "success": true, "data": { ...user } }`.

## Verification
- [x] Successfully built the backend server (`go build ./cmd/server`).
- [x] Verified no circular dependencies were introduced during the refactoring.
- [x] Manually tested the endpoint logic with the backend running.

---
- Closes #141 