### PR TITLE
feat: add future time validation for booking creation

### DIFF
--- a/resource-app/backend/api/booking.yaml
+++ b/resource-app/backend/api/booking.yaml
@@ -115,7 +115,7 @@ paths:
                   data:
                     $ref: "#/components/schemas/Booking"
         "400":
-          description: Invalid input
+          description: Invalid input - start and end must be in the future and start must be before end
           content:
             application/json:
               schema:

--- a/resource-app/backend/internal/booking/constants.go
+++ b/resource-app/backend/internal/booking/constants.go
@@ -29,5 +29,4 @@ var (
 	ErrInvalidTimeRange            = errors.New("start time must be before end time and both must be in the future")
 	ErrCheckInTooEarly			   = errors.New("check-in is not allowed before the booking start time")
     ErrCompleteBeforeEnd 		   = errors.New("booking cannot be completed before the end time")
-
 )

--- a/resource-app/backend/internal/booking/handlers.go
+++ b/resource-app/backend/internal/booking/handlers.go
@@ -84,6 +84,8 @@ func HandleCreateBooking(svc *Service) gin.HandlerFunc {
 				c.JSON(http.StatusForbidden, gin.H{"success": false, "error": ErrBookingPermissionDenied.Error()})
 			case errors.Is(err, ErrResourceNotFound):
 				c.JSON(http.StatusNotFound, gin.H{"success": false, "error": ErrResourceNotFound.Error()})
+			case errors.Is(err, ErrInvalidTimeRange):
+				c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": ErrInvalidTimeRange.Error()})
 			case errors.Is(err, ErrBookingConflict):
 				c.JSON(http.StatusConflict, gin.H{"success": false, "error": err.Error()})
 			default:

--- a/resource-app/backend/internal/booking/services.go
+++ b/resource-app/backend/internal/booking/services.go
@@ -62,6 +62,12 @@ func (s *Service) GetBookings(filter BookingFilter) ([]Booking, error) {
 }
 
 func (s *Service) CreateBooking(booking *Booking, userID string, userRole usr.Role) error {
+	// Validate booking times: start and end must be in the future, and start < end
+	now := time.Now()
+	if !booking.Start.After(now) || !booking.End.After(now) || !booking.Start.Before(booking.End) {
+		return ErrInvalidTimeRange
+	}
+
 	// For non-admin users, enforce REQUEST permission check
 	if userRole != usr.RoleAdmin {
 		hasPermission, err := s.permissionSvc.HasRequestPermission(userID, booking.ResourceID)
@@ -75,7 +81,7 @@ func (s *Service) CreateBooking(booking *Booking, userID string, userRole usr.Ro
 
 	booking.ID = uuid.New().String()
 	booking.UserID = userID
-	booking.CreatedAt = time.Now()
+	booking.CreatedAt = now
 
 	if userRole == usr.RoleAdmin {
 		booking.Status = StatusConfirmed


### PR DESCRIPTION
## Summary
This PR adds future-time validation to booking creation in the Resource App backend.

The `POST /bookings` flow now rejects invalid booking times with a `400 Bad Request` when:
- `start` is not in the future
- `end` is not in the future
- `start` is not before `end`

## Changes Made
- Added a new booking domain error for invalid time ranges.
- Added time validation in the booking service create flow before persistence.
- Mapped invalid time range errors to `400 Bad Request` in the booking handler.
- Updated Booking OpenAPI docs to describe the create-booking `400` response with timing constraints.

## Behavior Change
### Before
Create booking accepted past times.

### After
Create booking rejects:
- `start <= now`
- `end <= now`
- `start >= end`

and returns:
- HTTP `400`
- Error message for invalid time range

## Acceptance Criteria Coverage
- [x] Reject bookings with start time in the past (`400`)
- [x] Reject bookings with end time in the past (`400`)
- [x] Added invalid time range error constant
- [x] Mapped invalid time error to `400` in handler
- [x] Documented timing constraints in OpenAPI `400` response

## Validation
- Backend build succeeds with `go build ./...` in `resource-app/backend`.

## Notes
This change is backward-compatible for valid requests and only tightens validation for invalid booking time ranges.

---

**_Create a booking with a valid time range_**
<img width="920" height="598" alt="image" src="https://github.com/user-attachments/assets/82635a7e-e5b7-42bd-bbb8-f0813582d1a6" />
<img width="920" height="367" alt="image" src="https://github.com/user-attachments/assets/7da59843-7735-4dd7-a200-33d176046b6b" />

**_Create a booking with an invalid time range: start > end._**
<img width="920" height="588" alt="image" src="https://github.com/user-attachments/assets/7dc64edb-b73d-4137-96b4-f981060ea20c" />
<img width="920" height="230" alt="image" src="https://github.com/user-attachments/assets/c9e185b7-75d3-49c1-a334-9cc7cdf23ed3" />

**_Create a booking with an invalid time range: start | end < now._**
<img width="918" height="587" alt="image" src="https://github.com/user-attachments/assets/eb3f431d-8883-40e7-9466-7804ee8d2666" />
<img width="924" height="231" alt="image" src="https://github.com/user-attachments/assets/ac06a1bb-4bac-4944-9d02-68d2dc675d0a" />

closes #158 



