### PR TITLE
fix(resource-app): protect admin routes and fix booking authorization

### DIFF
--- a/resource-app/backend/cmd/server/main.go
+++ b/resource-app/backend/cmd/server/main.go
@@ -109,7 +109,9 @@ func main() {
 	adminGroup.Use(auth.RequireAdminMiddleware())
 
 	// Users
-	user.RegisterRoutes(apiGroup, userService)
+	apiGroup.GET("/users/me", user.HandleGetMe())
+	adminGroup.GET("/users", user.HandleGetUsers(userService))
+	adminGroup.PATCH("/users/:id/role", user.HandleUpdateUserRole(userService))
 
 	// Groups
 	apiGroup.GET("/me/groups", group.HandleGetMyGroups(groupService))
@@ -142,7 +144,7 @@ func main() {
 	apiGroup.DELETE("/bookings/:id", booking.HandleCancelBooking(bookingService))
 
 	// Stats
-	apiGroup.GET("/stats", booking.HandleGetStats(bookingService))
+	adminGroup.GET("/stats", booking.HandleGetStats(bookingService))
 	// holidays
 	apiGroup.GET("/holidays", api.HandleGetHolidays())
 

--- a/resource-app/backend/internal/booking/handlers.go
+++ b/resource-app/backend/internal/booking/handlers.go
@@ -148,23 +148,34 @@ func HandleUpdateBooking(svc *Service) gin.HandlerFunc {
 func HandleRescheduleBooking(svc *Service) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		id := c.Param("id")
+		user := auth.GetUserFromContext(c)
+		if user == nil {
+			c.JSON(http.StatusUnauthorized, gin.H{"success": false, "error": "User not authenticated"})
+			return
+		}
+
 		var req struct {
 			Start time.Time `json:"start" binding:"required"`
 			End   time.Time `json:"end" binding:"required"`
 		}
-		err := c.ShouldBindJSON(&req)
-		if err != nil {
+		if err := c.ShouldBindJSON(&req); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": err.Error()})
 			return
 		}
 
-		updated, err := svc.RescheduleBooking(id, req.Start, req.End)
+		updated, err := svc.RescheduleBooking(id, user.ID, user.Role, req.Start, req.End)
 		if err != nil {
 			switch {
 			case errors.Is(err, ErrBookingNotFound):
 				c.JSON(http.StatusNotFound, gin.H{"success": false, "error": ErrBookingNotFound.Error()})
 			case errors.Is(err, ErrRescheduleSlotConflict):
 				c.JSON(http.StatusConflict, gin.H{"success": false, "error": err.Error()})
+			case errors.Is(err, ErrForbidden):
+				c.JSON(http.StatusForbidden, gin.H{"success": false, "error": ErrForbidden.Error()})
+			case errors.Is(err, ErrInvalidTransition):
+				c.JSON(http.StatusUnprocessableEntity, gin.H{"success": false, "error": ErrInvalidTransition.Error()})
+			case errors.Is(err, ErrInvalidTimeRange):
+				c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": ErrInvalidTimeRange.Error()})
 			default:
 				c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "Failed to reschedule booking"})
 			}
@@ -178,11 +189,21 @@ func HandleRescheduleBooking(svc *Service) gin.HandlerFunc {
 func HandleCancelBooking(svc *Service) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		id := c.Param("id")
-		err := svc.CancelBooking(id)
+		user := auth.GetUserFromContext(c)
+		if user == nil {
+			c.JSON(http.StatusUnauthorized, gin.H{"success": false, "error": "User not authenticated"})
+			return
+		}
+
+		err := svc.CancelBooking(id, user.ID, user.Role)
 		if err != nil {
 			switch {
 			case errors.Is(err, ErrBookingNotFound):
 				c.JSON(http.StatusNotFound, gin.H{"success": false, "error": ErrBookingNotFound.Error()})
+			case errors.Is(err, ErrForbidden):
+				c.JSON(http.StatusForbidden, gin.H{"success": false, "error": ErrForbidden.Error()})
+			case errors.Is(err, ErrInvalidTransition):
+				c.JSON(http.StatusUnprocessableEntity, gin.H{"success": false, "error": ErrInvalidTransition.Error()})
 			default:
 				c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "Failed to cancel booking"})
 			}

--- a/resource-app/backend/internal/booking/services.go
+++ b/resource-app/backend/internal/booking/services.go
@@ -264,7 +264,7 @@ func (s *Service) RescheduleBooking(id, userID string, userRole usr.Role, newSta
 		return nil, ErrInvalidTimeRange
 	}
 
-	if userRole != usr.RoleAdmin {
+	if userRole != usr.RoleAdmin && booking.UserID != userID {
 		hasPermission, permErr := s.permissionSvc.HasApprovePermission(userID, booking.ResourceID)
 		if permErr != nil {
 			return nil, permErr
@@ -284,7 +284,13 @@ func (s *Service) CancelBooking(id, userID string, userRole usr.Role) error {
 	}
 
 	if booking.UserID != userID && userRole != usr.RoleAdmin {
-		return ErrForbidden
+		hasPermission, permErr := s.permissionSvc.HasApprovePermission(userID, booking.ResourceID)
+		if permErr != nil {
+			return permErr
+		}
+		if !hasPermission {
+			return ErrForbidden
+		}
 	}
 
 	if booking.Status == StatusCancelled {

--- a/resource-app/backend/internal/booking/services.go
+++ b/resource-app/backend/internal/booking/services.go
@@ -249,11 +249,51 @@ func (s *Service) proposeBooking(booking *Booking, userID string, userRole usr.R
 	})
 }
 
-func (s *Service) RescheduleBooking(id string, newStart, newEnd time.Time) (*Booking, error) {
+func (s *Service) RescheduleBooking(id, userID string, userRole usr.Role, newStart, newEnd time.Time) (*Booking, error) {
+	booking, err := s.repo.GetBookingByID(id)
+	if err != nil {
+		return nil, err
+	}
+
+	if booking.Status == StatusCancelled || booking.Status == StatusCompleted || booking.Status == StatusRejected {
+		return nil, ErrInvalidTransition
+	}
+
+	now := time.Now()
+	if !newStart.After(now) || !newEnd.After(now) || !newStart.Before(newEnd) {
+		return nil, ErrInvalidTimeRange
+	}
+
+	if userRole != usr.RoleAdmin {
+		hasPermission, permErr := s.permissionSvc.HasApprovePermission(userID, booking.ResourceID)
+		if permErr != nil {
+			return nil, permErr
+		}
+		if !hasPermission {
+			return nil, ErrForbidden
+		}
+	}
+
 	return s.repo.RescheduleBooking(id, newStart, newEnd)
 }
 
-func (s *Service) CancelBooking(id string) error {
+func (s *Service) CancelBooking(id, userID string, userRole usr.Role) error {
+	booking, err := s.repo.GetBookingByID(id)
+	if err != nil {
+		return err
+	}
+
+	if booking.UserID != userID && userRole != usr.RoleAdmin {
+		return ErrForbidden
+	}
+
+	if booking.Status == StatusCancelled {
+		return nil
+	}
+	if booking.Status == StatusCompleted || booking.Status == StatusRejected {
+		return ErrInvalidTransition
+	}
+
 	return s.repo.CancelBooking(id)
 }
 

--- a/resource-app/backend/internal/user/handlers.go
+++ b/resource-app/backend/internal/user/handlers.go
@@ -55,4 +55,3 @@ func HandleGetMe() gin.HandlerFunc {
 	}
 }
 
-

--- a/resource-app/backend/internal/user/handlers.go
+++ b/resource-app/backend/internal/user/handlers.go
@@ -55,12 +55,4 @@ func HandleGetMe() gin.HandlerFunc {
 	}
 }
 
-// RegisterRoutes registers the user routes
-func RegisterRoutes(rg *gin.RouterGroup, service *Service) {
-	users := rg.Group("/users")
-	{
-		users.GET("", HandleGetUsers(service))
-		users.GET("/me", HandleGetMe())
-		users.PATCH("/:id/role", HandleUpdateUserRole(service))
-	}
-}
+

--- a/resource-app/frontend/features/user/api.ts
+++ b/resource-app/frontend/features/user/api.ts
@@ -7,6 +7,15 @@ import { User, UserRole } from './types';
  * These are moved from the global api/client.ts as part of DDD refactoring.
  */
 export const userApi = {
+  getMe: async (): Promise<ApiResponse<User>> => {
+    try {
+      const response = await httpClient.get<{ data: User }>('/users/me');
+      return { success: true, data: response.data.data };
+    } catch (error: any) {
+      return { success: false, error: error.message || 'Failed to fetch current user' };
+    }
+  },
+
   getUsers: async (): Promise<ApiResponse<User[]>> => {
     try {
       const response = await httpClient.get<{ data: User[] }>('/users');

--- a/resource-app/frontend/features/user/api.ts
+++ b/resource-app/frontend/features/user/api.ts
@@ -25,10 +25,10 @@ export const userApi = {
     }
   },
 
-  updateUserRole: async (userId: string, role: UserRole): Promise<ApiResponse<void>> => {
+  updateUserRole: async (userId: string, role: UserRole): Promise<ApiResponse<User>> => {
     try {
-      await httpClient.patch(`/users/${userId}/role`, { role });
-      return { success: true };
+      const response = await httpClient.patch<{ data: User }>(`/users/${userId}/role`, { role });
+      return { success: true, data: response.data.data };
     } catch (error: any) {
       return { success: false, error: error.message || 'Failed to update user role' };
     }

--- a/resource-app/frontend/features/user/context.tsx
+++ b/resource-app/frontend/features/user/context.tsx
@@ -26,6 +26,8 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     const response = await userApi.getUsers();
     if (response.success && response.data) {
       setAllUsers(response.data);
+    } else {
+      throw new Error(response.error || 'Failed to fetch users');
     }
   }, []);
 
@@ -67,10 +69,11 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
   const updateUserRole = useCallback(async (userId: string, role: UserRole) => {
     try {
       const res = await userApi.updateUserRole(userId, role);
-      if (res.success) {
-        setAllUsers(prev => prev.map(u => u.id === userId ? { ...u, role } : u));
+      if (res.success && res.data) {
+        const updated = res.data;
+        setAllUsers(prev => prev.map(u => u.id === userId ? updated : u));
         if (currentUser?.id === userId) {
-          setCurrentUser(prev => prev ? { ...prev, role } : null);
+          setCurrentUser(updated);
         }
       } else {
         setError(res.error || "Failed to update user role");

--- a/resource-app/frontend/features/user/context.tsx
+++ b/resource-app/frontend/features/user/context.tsx
@@ -22,42 +22,56 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchUsers = useCallback(async () => {
+  const fetchAllUsers = useCallback(async () => {
+    const response = await userApi.getUsers();
+    if (response.success && response.data) {
+      setAllUsers(response.data);
+    }
+  }, []);
+
+  const fetchCurrentUser = useCallback(async () => {
     setIsLoading(true);
     setError(null);
     try {
+      const tokenData = await bridge.getToken();
+      const userEmail = tokenData.email;
+
+      if (!userEmail) {
+        throw new Error("Could not identify user from token");
+      }
+
       const response = await userApi.getMe();
       if (response.success && response.data) {
         setCurrentUser(response.data);
 
         if (response.data.role === UserRole.ADMIN) {
-          const allResponse = await userApi.getUsers();
-          if (allResponse.success && allResponse.data) {
-            setAllUsers(allResponse.data);
-          }
+          await fetchAllUsers();
         } else {
           setAllUsers([]);
         }
       } else {
         throw new Error(response.error || "Failed to fetch current user");
       }
-  } catch (err: unknown) {
-    console.error("UserProvider error:", err);
-    setError(err instanceof Error ? err.message : "Failed to initialize user context");
-  } finally {
-    setIsLoading(false);
-  }
-}, []);
+    } catch (err: unknown) {
+      console.error("UserProvider error:", err);
+      setError(err instanceof Error ? err.message : "Failed to initialize user context");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [fetchAllUsers]);
 
   useEffect(() => {
-    fetchUsers();
-  }, [fetchUsers]);
+    fetchCurrentUser();
+  }, [fetchCurrentUser]);
 
   const updateUserRole = useCallback(async (userId: string, role: UserRole) => {
     try {
       const res = await userApi.updateUserRole(userId, role);
       if (res.success) {
-        await fetchUsers();
+        setAllUsers(prev => prev.map(u => u.id === userId ? { ...u, role } : u));
+        if (currentUser?.id === userId) {
+          setCurrentUser(prev => prev ? { ...prev, role } : null);
+        }
       } else {
         setError(res.error || "Failed to update user role");
       }
@@ -65,7 +79,7 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
       console.error("updateUserRole error:", err);
       setError(err instanceof Error ? err.message : "An unexpected error occurred while updating user role");
     }
-  }, [fetchUsers]);
+  }, [currentUser]);
 
   const switchUser = useCallback((userId: string) => {
     const user = allUsers.find(u => u.id === userId);
@@ -82,7 +96,7 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
       allUsers,
       isLoading,
       error,
-      refreshUsers: fetchUsers,
+      refreshUsers: fetchCurrentUser,
       updateUserRole,
       switchUser,
       isAdmin

--- a/resource-app/frontend/features/user/context.tsx
+++ b/resource-app/frontend/features/user/context.tsx
@@ -26,29 +26,20 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     setIsLoading(true);
     setError(null);
     try {
-      // 1. Get identity from bridge
-      const tokenData = await bridge.getToken();
-      const userEmail = tokenData.email;
-
-      if (!userEmail) {
-        throw new Error("Could not identify user from token");
-      }
-
-      // 2. Fetch all users from API
-      const response = await userApi.getUsers();
-
+      const response = await userApi.getMe();
       if (response.success && response.data) {
-        setAllUsers(response.data);
-        
-        // 3. Find matching current user
-        const me = response.data.find(u => u.email === userEmail);
-        if (me) {
-          setCurrentUser(me);
+        setCurrentUser(response.data);
+
+        if (response.data.role === UserRole.ADMIN) {
+          const allResponse = await userApi.getUsers();
+          if (allResponse.success && allResponse.data) {
+            setAllUsers(allResponse.data);
+          }
         } else {
-          console.warn("User not found in user list despite valid token");
+          setAllUsers([]);
         }
       } else {
-        throw new Error(response.error || "Failed to fetch users");
+        throw new Error(response.error || "Failed to fetch current user");
       }
   } catch (err: unknown) {
     console.error("UserProvider error:", err);


### PR DESCRIPTION
## Summary

Restrict sensitive endpoints to admins and fix authorization checks in
booking mutations.

## Changes

### Backend
- `GET /users`, `PATCH /users/:id/role`, and `GET /stats` now require
  admin role (previously accessible to any authenticated user)
- `RescheduleBooking` and `CancelBooking` pull user from request context
  and verify ownership, admin role, or approve permission before proceeding
- `RescheduleBooking` rejects invalid targets (cancelled/completed/rejected
  bookings) and validates time range
- `CancelBooking` is idempotent for already-cancelled bookings

### Frontend
- Added `userApi.getMe()` calling `GET /users/me`
- `UserProvider` now calls `getMe()` directly instead of scanning the
  full user list for a matching email
- Non-admin users no longer fetch the user list at all
- `updateUserRole` uses the server response instead of local state mutation

Closes #163
